### PR TITLE
⚡ Bolt: Optimize duplicate CSS loading for animations

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-10-24 - Unnecessary Admin File Loading
 **Learning:** `includes/Admin/Module_Settings.php` and `includes/Admin/Plugin_Installer.php` were loaded unconditionally. Even without instantiation, parsing these files adds overhead.
 **Action:** Wrapped the `require_once` calls in `if ( is_admin() )` to ensure they are only loaded when needed.
+
+## 2025-02-18 - Duplicate CSS Resources
+**Learning:** The plugin was registering and enqueuing the same `animate.css` file 12 times with different handles (e.g., `e-animations`, `e-animation-fadeIn`) to override Elementor defaults. This resulted in 12 separate `<link>` tags pointing to the same file, bloating the DOM and potentially triggering multiple network requests.
+**Action:** Optimized by registering the file once under a primary handle and aliasing the other handles as dependencies (using `wp_register_style($alias, false, [$primary])`). This ensures the file is loaded only once while satisfying all handle requirements.

--- a/includes/Frontend/Assets.php
+++ b/includes/Frontend/Assets.php
@@ -67,8 +67,15 @@ class Assets
             }
 
             // Enqueue all handlers pointing to the same file
-            foreach ($handlers as $handler) {
-                wp_enqueue_style($handler, SPEL_VEND . '/animation/animate.css', [], SPEL_VERSION );
+            // Optimization: Load the file once via the first handler, and alias the rest.
+            if ( ! empty( $handlers ) ) {
+                $primary_handler = array_shift( $handlers );
+                wp_enqueue_style( $primary_handler, SPEL_VEND . '/animation/animate.css', [], SPEL_VERSION );
+
+                foreach ( $handlers as $handler ) {
+                    wp_register_style( $handler, false, [ $primary_handler ], SPEL_VERSION );
+                    wp_enqueue_style( $handler );
+                }
             }
 
         }


### PR DESCRIPTION
💡 **What:** Optimized the `register_widget_styles` method in `includes/Frontend/Assets.php`.
🎯 **Why:** The plugin was outputting ~12 duplicate `<link>` tags for `animate.css` to override Elementor animations, which bloated the DOM.
📊 **Impact:** Reduced the number of `<link>` tags for `animate.css` from ~12 to 1 on pages where this feature is active.
🔬 **Measurement:** Verified logic with a reproduction script demonstrating that aliasing handles via dependencies correctly deduplicates the output while maintaining handle availability. Confirmed syntax validity.

---
*PR created automatically by Jules for task [2439220650521965692](https://jules.google.com/task/2439220650521965692) started by @mdjwel*