### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix CSS injection and missing noopener in button links

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,15 @@ When parsing custom attributes from user input:
    - Or Whitelist: Only allow `data-*`, `aria-*`, `title`, `class`, `id`.
 2. **Handle Edge Cases:** Ensure `explode` has enough parts before accessing indexes to avoid PHP notices.
 3. **Defense in Depth:** Even if the input field is restricted to admins, protecting the output function guards against privilege escalation or DB compromises.
+
+## 2024-05-24 - CSS Injection and Reverse Tabnabbing
+**Vulnerability:**
+The `spel_button_link` function allowed `style` attributes in custom attributes, enabling potential site defacement. It also failed to add `rel="noopener"` to links with `target="_blank"`, exposing users to reverse tabnabbing attacks.
+
+**Learning:**
+1. `style` attributes can be used for defacement (e.g., covering the screen) even if XSS is blocked.
+2. `target="_blank"` requires `rel="noopener"` (or `noreferrer`) to prevent the new page from accessing the `window.opener` object. WordPress `esc_url` and `wp_kses` do not automatically enforce this context-dependent relationship.
+
+**Prevention:**
+1. Explicitly blacklist `style` in custom attribute parsers.
+2. Automatically inject `rel="noopener"` whenever `target="_blank"` is generated.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -81,7 +81,17 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 		if ( $is_echo ) {
 			echo ! empty( $settings_key['url'] ) ? 'href="' . esc_url( $settings_key['url'] ) . '"' : '';
 			echo $settings_key['is_external'] ? ' target="_blank"' : '';
-			echo $settings_key['nofollow'] ? ' rel="nofollow"' : '';
+
+			$rel_attributes = [];
+			if ( $settings_key['nofollow'] ) {
+				$rel_attributes[] = 'nofollow';
+			}
+			if ( $settings_key['is_external'] ) {
+				$rel_attributes[] = 'noopener';
+			}
+			if ( ! empty( $rel_attributes ) ) {
+				echo ' rel="' . esc_attr( implode( ' ', $rel_attributes ) ) . '"';
+			}
 
 			if ( ! empty( $settings_key['custom_attributes'] ) ) {
 				$attrs = explode( ',', $settings_key['custom_attributes'] );
@@ -95,8 +105,8 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 						// Security: Sanitize attribute name (allow alphanumeric, dashes, colons)
 						$attr_name = preg_replace( '/[^a-zA-Z0-9_\-:]/', '', $attr_name );
 
-						// Security: Prevent XSS by blocking event handlers (on*) and critical attributes
-						if ( preg_match( '/^(on|href|src|formaction)/i', $attr_name ) ) {
+						// Security: Prevent XSS by blocking event handlers (on*), style, and critical attributes
+						if ( preg_match( '/^(on|style|target|href|src|formaction)/i', $attr_name ) ) {
 							continue;
 						}
 


### PR DESCRIPTION
This PR hardens the `spel_button_link` helper function by:
1. Expanding the custom attribute blacklist to include `style` and `target`. This prevents malicious CSS injection (site defacement) and conflicting target attributes.
2. Automatically appending `rel="noopener"` when `target="_blank"` is set (via `is_external` setting). This mitigates reverse tabnabbing vulnerabilities where a malicious new page could access the original window object.
3. Refactoring the `rel` attribute output to correctly merge `nofollow` and `noopener` values, ensuring valid HTML output.

These changes are backward compatible for standard usage but enforce stricter security on custom attribute inputs.

---
*PR created automatically by Jules for task [7015705382156845519](https://jules.google.com/task/7015705382156845519) started by @mdjwel*