### PR TITLE
⚡ Bolt: Lazy load extension classes to reduce bootstrap overhead

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-10-24 - Unnecessary Admin File Loading
 **Learning:** `includes/Admin/Module_Settings.php` and `includes/Admin/Plugin_Installer.php` were loaded unconditionally. Even without instantiation, parsing these files adds overhead.
 **Action:** Wrapped the `require_once` calls in `if ( is_admin() )` to ensure they are only loaded when needed.
+
+## 2024-10-26 - Optimized Conditional File Loading in Bootstrap
+**Learning:** `Heading_Highlighted.php` and `Features_Badge.php` were being required unconditionally in `core_includes` (during `__construct`) if the theme matched, even if the features were disabled. This triggered unnecessary `wp_get_theme()` calls and file parsing.
+**Action:** Removed the early require and moved `require_once` into `init_plugin` (hooked to `plugins_loaded`), nesting it inside the specific feature enablement check. This ensures files are only loaded when actually needed and avoids one `wp_get_theme()` call on bootstrap.

--- a/spider-elements.php
+++ b/spider-elements.php
@@ -252,12 +252,6 @@ if ( ! class_exists( 'SPEL' ) ) {
 			//Action Filter
 			require_once __DIR__ . '/includes/filters.php';
 
-			$theme = wp_get_theme();
-			if ( spel_is_premium() || in_array( $theme->get( 'Name' ), [ 'jobi', 'Jobi', 'jobi-child', 'Jobi Child' ] ) ) {
-				require_once __DIR__ . '/includes/Admin/extension/Heading_Highlighted.php';
-				require_once __DIR__ . '/includes/Admin/extension/Features_Badge.php';
-			}
-
 			// Admin UI
 			if ( is_admin() ) {
 				require_once __DIR__ . '/includes/Admin/Module_Settings.php';
@@ -295,11 +289,13 @@ if ( ! class_exists( 'SPEL' ) ) {
 				// Get the feature badge status
 				$heading_highlighted = $features_opt['spel_heading_highlighted'] ?? '';
 				if ( $heading_highlighted ) {
+					require_once __DIR__ . '/includes/Admin/extension/Heading_Highlighted.php';
 					new SPEL\includes\Admin\extension\Heading_Highlighted();
 				}
 
 				$badge = $features_opt['spel_badge'] ?? '';
 				if ( $badge ) {
+					require_once __DIR__ . '/includes/Admin/extension/Features_Badge.php';
 					new SPEL\includes\Admin\extension\Features_Badge();
 				}
 


### PR DESCRIPTION
* 💡 **What:** Moved `Heading_Highlighted.php` and `Features_Badge.php` loading from unconditional `core_includes` to conditional `init_plugin`.
* 🎯 **Why:** To avoid parsing these files and calling `wp_get_theme()` unnecessarily during plugin bootstrap (`__construct`), especially when features are disabled.
* 📊 **Impact:** Eliminated 1 `wp_get_theme()` call per request. Reduced file I/O and parsing by 2 files when features are disabled. Deferred loading to `plugins_loaded` hook.
* 🔬 **Measurement:** Verified with `reproduce_issue.php` script showing reduction in `wp_get_theme` calls from 2 to 1 and preventing file loading when features are off.

---
*PR created automatically by Jules for task [3495519075140944129](https://jules.google.com/task/3495519075140944129) started by @mdjwel*