### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix reverse tabnabbing and attribute injection

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -81,7 +81,17 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 		if ( $is_echo ) {
 			echo ! empty( $settings_key['url'] ) ? 'href="' . esc_url( $settings_key['url'] ) . '"' : '';
 			echo $settings_key['is_external'] ? ' target="_blank"' : '';
-			echo $settings_key['nofollow'] ? ' rel="nofollow"' : '';
+
+			$rel_attributes = [];
+			if ( $settings_key['nofollow'] ) {
+				$rel_attributes[] = 'nofollow';
+			}
+			if ( $settings_key['is_external'] ) {
+				$rel_attributes[] = 'noopener';
+			}
+			if ( ! empty( $rel_attributes ) ) {
+				echo ' rel="' . esc_attr( implode( ' ', $rel_attributes ) ) . '"';
+			}
 
 			if ( ! empty( $settings_key['custom_attributes'] ) ) {
 				$attrs = explode( ',', $settings_key['custom_attributes'] );
@@ -96,7 +106,7 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 						$attr_name = preg_replace( '/[^a-zA-Z0-9_\-:]/', '', $attr_name );
 
 						// Security: Prevent XSS by blocking event handlers (on*) and critical attributes
-						if ( preg_match( '/^(on|href|src|formaction)/i', $attr_name ) ) {
+						if ( preg_match( '/^(on|href|src|formaction|style|target|rel)/i', $attr_name ) ) {
 							continue;
 						}
 


### PR DESCRIPTION
This PR addresses a Reverse Tabnabbing vulnerability and an Attribute Injection risk in the `spel_button_link` function.

1.  **Reverse Tabnabbing**: Previously, external links (`target="_blank"`) did not include `rel="noopener"`. This allowed the opened page to potentially control the parent page via `window.opener`. This fix ensures `noopener` is always added for external links.
2.  **Attribute Injection**: The custom attribute parser allowed `style`, `target`, and `rel` attributes.
    -   `style` injection allows CSS defacement.
    -   `target` and `rel` injection allows overriding the intended behavior (e.g., forcing `target="_self"` or removing `nofollow`).
    These attributes are now blocked in the custom attribute parser.

Verified with a reproduction script to ensure `rel` is correctly constructed and dangerous attributes are blocked.

---
*PR created automatically by Jules for task [6341961938549366385](https://jules.google.com/task/6341961938549366385) started by @mdjwel*