### PR TITLE
📋 Warden: Code Quality & WPCS Cleanup

### DIFF
--- a/spider-elements.php
+++ b/spider-elements.php
@@ -58,10 +58,10 @@ if ( function_exists( 'spel_fs' ) ) {
 							'support'    => false,
 							'first-path' => 'admin.php?page=spider_elements_settings'
 						],
-						'parallel_activation' => array(
+						'parallel_activation' => [
 							'enabled'                  => true,
 							'premium_version_basename' => 'spider-elements-pro/spider-elements.php',
-						),
+						],
 					]
 				);
 			}
@@ -130,7 +130,7 @@ if ( ! class_exists( 'SPEL' ) ) {
 		 *
 		 */
 		public static function instance() {
-			if ( is_null( self::$_instance ) ) {
+			if ( null === self::$_instance ) {
 				self::$_instance = new self();
 			}
 
@@ -253,7 +253,7 @@ if ( ! class_exists( 'SPEL' ) ) {
 			require_once __DIR__ . '/includes/filters.php';
 
 			$theme = wp_get_theme();
-			if ( spel_is_premium() || in_array( $theme->get( 'Name' ), [ 'jobi', 'Jobi', 'jobi-child', 'Jobi Child' ] ) ) {
+			if ( spel_is_premium() || in_array( $theme->get( 'Name' ), [ 'jobi', 'Jobi', 'jobi-child', 'Jobi Child' ], true ) ) {
 				require_once __DIR__ . '/includes/Admin/extension/Heading_Highlighted.php';
 				require_once __DIR__ . '/includes/Admin/extension/Features_Badge.php';
 			}
@@ -288,7 +288,7 @@ if ( ! class_exists( 'SPEL' ) ) {
 
 			$theme               = wp_get_theme();
 			$features_opt        = get_option( 'spel_features_settings' );
-			$is_premium_or_theme = spel_is_premium() || in_array( $theme->get( 'Name' ), [ 'jobi', 'Jobi', 'jobi-child', 'Jobi Child' ] );
+			$is_premium_or_theme = spel_is_premium() || in_array( $theme->get( 'Name' ), [ 'jobi', 'Jobi', 'jobi-child', 'Jobi Child' ], true );
 
 			if ( $is_premium_or_theme ) {
 
@@ -366,7 +366,7 @@ if ( ! class_exists( 'SPEL' ) ) {
 
 			// Register active widgets
 			foreach ( $widgets as $key => $widget ) {
-				if ( ! isset( $elements_opt[ $key ] ) || $elements_opt[ $key ] === 'on' ) {
+				if ( ! isset( $elements_opt[ $key ] ) || 'on' === $elements_opt[ $key ] ) {
 					require_once( __DIR__ . "/widgets/$widget.php" );
 					$classname = "\\SPEL\\Widgets\\$widget";
 					$widgets_manager->register( new $classname() );

--- a/widgets/Accordion.php
+++ b/widgets/Accordion.php
@@ -50,8 +50,9 @@ class Accordion extends Widget_Base {
 	}
 
 	/**
-	 * Name: get_style_depends()
-	 * Desc: Register the required CSS dependencies for the frontend.
+	 * Register the required CSS dependencies for the frontend.
+	 *
+	 * @return array
 	 */
 	public function get_style_depends(): array
     {
@@ -59,8 +60,9 @@ class Accordion extends Widget_Base {
 	}
 
 	/**
-	 * Name: get_script_depends()
-	 * Desc: Register the required JS dependencies for the frontend.
+	 * Register the required JS dependencies for the frontend.
+	 *
+	 * @return array
 	 */
 	public function get_script_depends(): array
     {
@@ -69,13 +71,10 @@ class Accordion extends Widget_Base {
 
 
 	/**
-	 * Name: register_controls()
-	 * Desc: Register controls for these widgets
-	 * Params: no params
-	 * Return: @void
-	 * Since: @1.0.0
-	 * Package: @spider-elements
-	 * Author: spider-themes
+	 * Register controls for these widgets.
+	 *
+	 * @return void
+	 * @since 1.0.0
 	 */
 	protected function register_controls(): void
     {
@@ -85,13 +84,10 @@ class Accordion extends Widget_Base {
 
 
 	/**
-	 * Name: elementor_content_control()
-	 * Desc: Register the Content Tab output on the Elementor editor.
-	 * Params: no params
-	 * Return: @void
-	 * Since: @1.0.0
-	 * Package: @spider-elements
-	 * Author: spider-themes
+	 * Register the Content Tab output on the Elementor editor.
+	 *
+	 * @return void
+	 * @since 1.0.0
 	 */
 	public function elementor_content_control(): void
     {
@@ -298,13 +294,10 @@ class Accordion extends Widget_Base {
 
 
 	/**
-	 * Name: elementor_style_control()
-	 * Desc: Register the Style Tab output on the Elementor editor.
-	 * Params: no params
-	 * Return: @void
-	 * Since: @1.0.0
-	 * Package: @spider-elements
-	 * Author: spider-themes
+	 * Register the Style Tab output on the Elementor editor.
+	 *
+	 * @return void
+	 * @since 1.0.0
 	 */
 	public function elementor_style_control(): void
     {
@@ -642,13 +635,10 @@ class Accordion extends Widget_Base {
 	//	==================End accordion all style controls===============
 
 	/**
-	 * Name: elementor_render()
-	 * Desc: Render the widget output on the frontend.
-	 * Params: no params
-	 * Return: @void
-	 * Since: @1.0.0
-	 * Package: @spider-elements
-	 * Author: spider-themes
+	 * Render the widget output on the frontend.
+	 *
+	 * @return void
+	 * @since 1.0.0
 	 */
 	protected function render(): void
     {
@@ -659,11 +649,11 @@ class Accordion extends Widget_Base {
 		$title_tag 		  = Utils::validate_html_tag( $settings['title_tag'] ?? 'h6' );
 		$accordions       = ! empty ( $settings['accordions'] ) ? $settings['accordions'] : '';
 		$icon_align       = ! empty ( $settings['icon_align'] ) ? $settings['icon_align'] : 'right';
-		$icon_align_class = ! empty ( $icon_align == 'left' ) ? ' icon-align-left' : '';
+		$icon_align_class = 'left' === $icon_align ? ' icon-align-left' : '';
 
 		$is_toggle           = ! empty ( $settings['is_toggle'] ) ? $settings['is_toggle'] : '';
-		$toggle_id           = ! empty( $is_toggle == 'yes' ) ? 'id=accordionExample-' . $this->get_id() : '';
-		$toggle_bs_parent_id = ! empty( $is_toggle == 'yes' ) ? 'data-bs-parent=#accordionExample-' . $this->get_id() : '';
+		$toggle_id           = 'yes' === $is_toggle ? 'id=accordionExample-' . $this->get_id() : '';
+		$toggle_bs_parent_id = 'yes' === $is_toggle ? 'data-bs-parent=#accordionExample-' . $this->get_id() : '';
 
 		//======================== Template Parts ========================//
 		include "templates/accordion/accordion.php";

--- a/widgets/Icon_Box.php
+++ b/widgets/Icon_Box.php
@@ -57,16 +57,18 @@ class Icon_Box extends Widget_Base {
 	}
 
 	/**
-	 * Name: get_style_depends()
-	 * Desc: Register the required CSS dependencies for the frontend.
+	 * Register the required CSS dependencies for the frontend.
+	 *
+	 * @return array
 	 */
 	public function get_style_depends() {
 		return [ 'spel-main', 'elegant-icon' ];
 	}
 
 	/**
-	 * Name: get_script_depends()
-	 * Desc: Register the required JS dependencies for the frontend.
+	 * Register the required JS dependencies for the frontend.
+	 *
+	 * @return array
 	 */
 	public function get_script_depends() {
 		return [ 'spel-el-widgets' ];
@@ -74,13 +76,10 @@ class Icon_Box extends Widget_Base {
 
 
 	/**
-	 * Name: register_controls()
-	 * Desc: Register controls for these widgets
-	 * Params: no params
-	 * Return: @void
-	 * Since: @1.0.0
-	 * Package: @spider-elements
-	 * Author: spider-themes
+	 * Register controls for these widgets.
+	 *
+	 * @return void
+	 * @since 1.0.0
 	 */
 	protected function register_controls() {
 		$this->elementor_content_control();
@@ -90,13 +89,10 @@ class Icon_Box extends Widget_Base {
 
 
 	/**
-	 * Name: elementor_content_control()
-	 * Desc: Register the Content Tab output on the Elementor editor.
-	 * Params: no params
-	 * Return: @void
-	 * Since: @1.0.0
-	 * Package: @spider-elements
-	 * Author: spider-themes
+	 * Register the Content Tab output on the Elementor editor.
+	 *
+	 * @return void
+	 * @since 1.0.0
 	 */
 	public function elementor_content_control() { //start icon box settings
 
@@ -283,13 +279,10 @@ class Icon_Box extends Widget_Base {
 
 
 	/**
-	 * Name: elementor_style_control()
-	 * Desc: Register the Style Tab output on the Elementor editor.
-	 * Params: no params
-	 * Return: @void
-	 * Since: @1.0.0
-	 * Package: @spider-elements
-	 * Author: spider-themes
+	 * Register the Style Tab output on the Elementor editor.
+	 *
+	 * @return void
+	 * @since 1.0.0
 	 */
 	//==================Start Icon Box all style controls===============//
 	public function elementor_style_control() {
@@ -983,7 +976,7 @@ class Icon_Box extends Widget_Base {
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/Icon-box/icon-box{$style}.php";
 	}

--- a/widgets/Team_Carousel.php
+++ b/widgets/Team_Carousel.php
@@ -43,16 +43,18 @@ class Team_Carousel extends Widget_Base {
 	}
 
 	/**
-	 * Name: get_style_depends()
-	 * Desc: Register the required CSS dependencies for the frontend.
+	 * Register the required CSS dependencies for the frontend.
+	 *
+	 * @return array
 	 */
 	public function get_style_depends() {
 		return [ 'elegant-icon', 'slick', 'slick-theme', 'spel-main' ];
 	}
 
 	/**
-	 * Name: get_script_depends()
-	 * Desc: Register the required JS dependencies for the frontend.
+	 * Register the required JS dependencies for the frontend.
+	 *
+	 * @return array
 	 */
 	public function get_script_depends() {
 		return [ 'slick', 'spel-el-widgets' ];
@@ -60,13 +62,10 @@ class Team_Carousel extends Widget_Base {
 
 
 	/**
-	 * Name: register_controls()
-	 * Desc: Register controls for these widgets
-	 * Params: no params
-	 * Return: @void
-	 * Since: @1.0.0
-	 * Package: @spider-elements
-	 * Author: spider-themes
+	 * Register controls for these widgets.
+	 *
+	 * @return void
+	 * @since 1.0.0
 	 */
 	protected function register_controls() {
 		$this->elementor_content_control();
@@ -76,13 +75,10 @@ class Team_Carousel extends Widget_Base {
 
 
 	/**
-	 * Name: elementor_content_control()
-	 * Desc: Register the Content Tab output on the Elementor editor.
-	 * Params: no params
-	 * Return: @void
-	 * Since: @1.0.0
-	 * Package: @spider-elements
-	 * Author: spider-themes
+	 * Register the Content Tab output on the Elementor editor.
+	 *
+	 * @return void
+	 * @since 1.0.0
 	 */
 
 	public function elementor_content_control() {
@@ -209,13 +205,10 @@ class Team_Carousel extends Widget_Base {
 
 
 	/**
-	 * Name: elementor_style_control()
-	 * Desc: Register the Style Tab output on the Elementor editor.
-	 * Params: no params
-	 * Return: @void
-	 * Since: @1.0.0
-	 * Package: @spider-elements
-	 * Author: spider-themes
+	 * Register the Style Tab output on the Elementor editor.
+	 *
+	 * @return void
+	 * @since 1.0.0
 	 */
 	public function team_style_control() {
 
@@ -338,13 +331,10 @@ class Team_Carousel extends Widget_Base {
 	}
 
 	/**
-	 * Name: elementor_render()
-	 * Desc: Render the widget output on the frontend.
-	 * Params: no params
-	 * Return: @void
-	 * Since: @1.0.0
-	 * Package: @spider-elements
-	 * Author: spider-themes
+	 * Render the widget output on the frontend.
+	 *
+	 * @return void
+	 * @since 1.0.0
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
@@ -352,7 +342,7 @@ class Team_Carousel extends Widget_Base {
 		$team_id = $this->get_id();
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/team/team-{$style}.php";
 	}


### PR DESCRIPTION
## 📋 Warden: Code Quality & WPCS Cleanup

### 💡 What Changed
- **spider-elements.php**: Converted `array()` to `[]`, enforced strict `in_array` checks, and applied Yoda conditions.
- **widgets/Accordion.php**: Refactored `! empty( $var == 'value' )` logic to strict comparisons, and fixed non-standard docblocks.
- **widgets/Icon_Box.php**: Standardized array syntax to `[]` and fixed docblocks.
- **widgets/Team_Carousel.php**: Standardized array syntax to `[]` and fixed docblocks.

### 🎯 Why
- Addresses WPCS violations regarding array syntax consistency (forcing `[]`).
- Improves type safety and logical clarity by replacing loose comparisons and weird boolean logic with strict checks (`===`).
- Standardizes documentation for better maintainability.

### 📊 Impact
- **Code quality:** Improved consistency and readability.
- **Behavior:** No functional changes. The logic refactoring preserves existing behavior while being safer.

### 🧪 How Tested
- [x] PHP syntax check: `php -l` on all modified files.
- [x] Manual verification of logic equivalence for `Accordion.php`.

---
*PR created automatically by Jules for task [9028787343932070559](https://jules.google.com/task/9028787343932070559) started by @mdjwel*