### PR TITLE
⚡ Bolt: Deduplicate Animation CSS loading

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-10-24 - Unnecessary Admin File Loading
 **Learning:** `includes/Admin/Module_Settings.php` and `includes/Admin/Plugin_Installer.php` were loaded unconditionally. Even without instantiation, parsing these files adds overhead.
 **Action:** Wrapped the `require_once` calls in `if ( is_admin() )` to ensure they are only loaded when needed.
+
+## 2024-05-23 - Redundant CSS Enqueues via Loop
+**Learning:** Found a loop in `includes/Frontend/Assets.php` that deregistered 12 Elementor animation handles and re-enqueued each one pointing to the same `animate.css` file. This caused the same file to be requested multiple times (or at least clutter the DOM with duplicate link tags).
+**Action:** When replacing multiple handles with a single resource, register the resource once with a primary handle, and register the others as aliases (dependencies) with `src = false`.

--- a/includes/Frontend/Assets.php
+++ b/includes/Frontend/Assets.php
@@ -61,14 +61,16 @@ class Assets
                 'e-animation-grow',
             ];
 
-            // Deregister all styles for the handlers
-            foreach ($handlers as $handler) {
-                wp_deregister_style($handler);
-            }
+            // Register the primary handle once
+            wp_register_style( 'spel-animate', SPEL_VEND . '/animation/animate.css', [], SPEL_VERSION );
 
-            // Enqueue all handlers pointing to the same file
-            foreach ($handlers as $handler) {
-                wp_enqueue_style($handler, SPEL_VEND . '/animation/animate.css', [], SPEL_VERSION );
+            // Deregister all styles for the handlers and re-register as aliases
+            foreach ( $handlers as $handler ) {
+                wp_deregister_style( $handler );
+                // Register as alias (dependency on primary)
+                wp_register_style( $handler, false, [ 'spel-animate' ] );
+                // Enqueue to ensure the dependency is loaded if this handle is requested
+                wp_enqueue_style( $handler );
             }
 
         }


### PR DESCRIPTION
* 💡 **What:** Optimized the loading of `animate.css` in `includes/Frontend/Assets.php`.
* 🎯 **Why:** The previous code looped through 12 Elementor animation handles and enqueued the same CSS file for each one, causing up to 12 duplicate requests or DOM elements.
* 📊 **Impact:** Reduces HTTP requests/DOM elements for `animate.css` from ~12 to 1 on pages where smooth animation is enabled.
* 🔬 **Measurement:** Verified with a mock script `test_styles.php` that the number of printed `<link>` tags reduced from 3 (in test) to 1. Logic uses `wp_register_style(..., false, ...)` to alias handles.

---
*PR created automatically by Jules for task [7144429181579161895](https://jules.google.com/task/7144429181579161895) started by @mdjwel*