### PR TITLE
🛡️ Sentinel: Fix reverse tabnabbing and attribute injection in button links

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -81,7 +81,18 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 		if ( $is_echo ) {
 			echo ! empty( $settings_key['url'] ) ? 'href="' . esc_url( $settings_key['url'] ) . '"' : '';
 			echo $settings_key['is_external'] ? ' target="_blank"' : '';
-			echo $settings_key['nofollow'] ? ' rel="nofollow"' : '';
+
+			$rel_attributes = [];
+			if ( $settings_key['nofollow'] ) {
+				$rel_attributes[] = 'nofollow';
+			}
+			if ( $settings_key['is_external'] ) {
+				$rel_attributes[] = 'noopener';
+			}
+
+			if ( ! empty( $rel_attributes ) ) {
+				echo ' rel="' . esc_attr( implode( ' ', $rel_attributes ) ) . '"';
+			}
 
 			if ( ! empty( $settings_key['custom_attributes'] ) ) {
 				$attrs = explode( ',', $settings_key['custom_attributes'] );
@@ -96,7 +107,7 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 						$attr_name = preg_replace( '/[^a-zA-Z0-9_\-:]/', '', $attr_name );
 
 						// Security: Prevent XSS by blocking event handlers (on*) and critical attributes
-						if ( preg_match( '/^(on|href|src|formaction)/i', $attr_name ) ) {
+						if ( preg_match( '/^(on|href|src|formaction|style|target|rel)/i', $attr_name ) ) {
 							continue;
 						}
 


### PR DESCRIPTION
*   SEVERITY: Medium (Reverse Tabnabbing + CSS Injection)
*   SUMMARY: The helper function `spel_button_link` failed to add `rel="noopener"` to external links, exposing users to reverse tabnabbing attacks. Additionally, it allowed `style`, `target`, and `rel` attributes in custom fields, enabling potential CSS injection and attribute overriding.
*   IMPACT: Attackers could potentially redirect users from a linked page or inject malicious styles/attributes.
*   FIX: Added `rel="noopener"` logic for external links and expanded the attribute blocklist to include `style`, `target`, and `rel`.
*   VERIFICATION: Run `verify_fix.php` to ensure that `noopener` is present and dangerous attributes are stripped.

---
*PR created automatically by Jules for task [5581317097546014389](https://jules.google.com/task/5581317097546014389) started by @mdjwel*