### PR TITLE
Core Includes Cleanup & WPCS Standardization

### DIFF
--- a/spider-elements.php
+++ b/spider-elements.php
@@ -58,10 +58,10 @@ if ( function_exists( 'spel_fs' ) ) {
 							'support'    => false,
 							'first-path' => 'admin.php?page=spider_elements_settings'
 						],
-						'parallel_activation' => array(
+						'parallel_activation' => [
 							'enabled'                  => true,
 							'premium_version_basename' => 'spider-elements-pro/spider-elements.php',
-						),
+						],
 					]
 				);
 			}
@@ -366,7 +366,7 @@ if ( ! class_exists( 'SPEL' ) ) {
 
 			// Register active widgets
 			foreach ( $widgets as $key => $widget ) {
-				if ( ! isset( $elements_opt[ $key ] ) || $elements_opt[ $key ] === 'on' ) {
+				if ( ! isset( $elements_opt[ $key ] ) || 'on' === $elements_opt[ $key ] ) {
 					require_once( __DIR__ . "/widgets/$widget.php" );
 					$classname = "\\SPEL\\Widgets\\$widget";
 					$widgets_manager->register( new $classname() );


### PR DESCRIPTION
## 📋 Warden: Core Includes Cleanup & WPCS Standardization

### 💡 What Changed
- **`includes/functions.php`**:
    - Fixed `spel_readable_number` logic: it was incorrectly calculating file sizes (e.g., 1GB was returned as 1024 bytes). It now correctly handles KB, MB, GB, TB, PB.
    - Refactored `spel_button_link`: Changed from scattered `echo` statements to building a string and echoing once. This improves readability and maintainability.
    - Deprecated `spel_archive_query`: The function was empty/no-op but hooked to `pre_get_posts`. Removed the hook and added `_deprecated_function`.
    - Standardized array syntax to `[]`.
    - Fixed indentation and spacing issues (WPCS).
    - Improved `spel_pagination` readability.
- **`spider-elements.php`**:
    - Standardized array syntax to `[]`.
    - Applied WPCS formatting (Yoda conditions, spacing).

### 🎯 Why
- **WPCS Compliance:** The codebase had inconsistent array syntax and formatting.
- **Logic Fix:** `spel_readable_number` was fundamentally broken, returning incorrect values for anything larger than KB. This is a critical utility function for system status checks.
- **Maintainability:** `spel_button_link` was hard to read and modify. The refactor makes it cleaner.
- **Performance:** Removed a useless hook (`spel_archive_query`) that ran on every query.

### 📊 Impact
- **Code Quality:** Significantly improved consistency and readability in core files.
- **Behavior:**
    - `spel_readable_number` now returns **correct** byte values (e.g., 1GB = 1073741824 bytes, previously 1024). This is a *behavior change* but a necessary bug fix.
    - `spel_button_link` output is identical to before.
    - `spel_archive_query` no longer runs on `pre_get_posts` (it was doing nothing anyway).

### 🧪 How Tested
- [x] PHP Syntax Check: `php -l includes/functions.php`, `php -l spider-elements.php` passed.
- [x] Logic Verification: Created `verify_logic.php` to test `spel_readable_number` (verified correct calculation) and `spel_button_link` (verified correct HTML output).
- [x] Manual Review: Verified code structure and formatting.

### 🧩 Compatibility Notes
- PHP: 7.4+ (required by plugin)
- WordPress: 5.0+

---
*PR created automatically by Jules for task [17377622062365013894](https://jules.google.com/task/17377622062365013894) started by @mdjwel*