### PR TITLE
⚡ Bolt: Optimize WP_Query in template retrieval

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-10-24 - Unnecessary Admin File Loading
 **Learning:** `includes/Admin/Module_Settings.php` and `includes/Admin/Plugin_Installer.php` were loaded unconditionally. Even without instantiation, parsing these files adds overhead.
 **Action:** Wrapped the `require_once` calls in `if ( is_admin() )` to ensure they are only loaded when needed.
+
+## 2024-10-25 - Efficient WP_Query for Lists
+**Learning:** `WP_Query` defaults to `SQL_CALC_FOUND_ROWS` and priming meta/term caches, which is wasteful for simple ID/Title dropdown lists. This is especially impactful when querying all posts (`posts_per_page => -1`).
+**Action:** Use `'no_found_rows' => true`, `'update_post_meta_cache' => false`, and `'update_post_term_cache' => false` when only IDs and titles are needed. Also iterate `$query->posts` directly to avoid `the_post()` global state overhead.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -550,23 +550,24 @@ if ( ! function_exists( 'spel_dynamic_image' ) ) {
 if ( ! function_exists( 'spel_get_query_post_list' ) ) {
 	function spel_get_query_post_list( $post_type = 'any', $limit = -1, $search = '' ): array {
 		$args = [
-			'post_type'      => $post_type,
-			'post_status'    => 'publish',
-			'posts_per_page' => $limit,
-			's'              => $search, // Search term
+			'post_type'              => $post_type,
+			'post_status'            => 'publish',
+			'posts_per_page'         => $limit,
+			's'                      => $search, // Search term
+			'no_found_rows'          => true,
+			'update_post_meta_cache' => false,
+			'update_post_term_cache' => false,
 		];
 
 		$query = new WP_Query( $args );
 
 		$data = [];
 		if ( $query->have_posts() ) {
-			while ( $query->have_posts() ) {
-				$query->the_post();
-				$data[ get_the_ID() ] = get_the_title();
+			foreach ( $query->posts as $post ) {
+				// Bolt Optimization: Use direct post object to avoid the_post() loop and meta/term cache queries
+				$data[ $post->ID ] = get_the_title( $post );
 			}
 		}
-
-		wp_reset_postdata(); // Reset post data after custom query
 
 		return $data;
 	}


### PR DESCRIPTION
💡 **What:** Optimized `spel_get_query_post_list` function in `includes/functions.php`.
🎯 **Why:** The function was using default `WP_Query` arguments which include `SQL_CALC_FOUND_ROWS` and priming of meta and term caches, even though only IDs and Titles were used. This is inefficient, especially with `posts_per_page => -1` (loading all templates).
📊 **Impact:** Reduced database queries (saves at least 2 queries per call by skipping cache priming) and reduced CPU/Memory overhead by avoiding `SQL_CALC_FOUND_ROWS` and global `the_post()` setup.
🔬 **Measurement:** Verified using a reproduction script that confirms the new arguments are passed to `WP_Query` and `the_post()` is no longer called.

---
*PR created automatically by Jules for task [14487003293398361852](https://jules.google.com/task/14487003293398361852) started by @mdjwel*