### PR TITLE
Sentinel: [MEDIUM] Fix attribute injection and missing noopener in spel_button_link

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -81,7 +81,19 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 		if ( $is_echo ) {
 			echo ! empty( $settings_key['url'] ) ? 'href="' . esc_url( $settings_key['url'] ) . '"' : '';
 			echo $settings_key['is_external'] ? ' target="_blank"' : '';
-			echo $settings_key['nofollow'] ? ' rel="nofollow"' : '';
+
+			// Sentinel: Enhanced security for external links and attribute blocking
+			$rel_attributes = [];
+			if ( $settings_key['nofollow'] ) {
+				$rel_attributes[] = 'nofollow';
+			}
+			if ( $settings_key['is_external'] ) {
+				$rel_attributes[] = 'noopener';
+			}
+
+			if ( ! empty( $rel_attributes ) ) {
+				echo ' rel="' . esc_attr( implode( ' ', $rel_attributes ) ) . '"';
+			}
 
 			if ( ! empty( $settings_key['custom_attributes'] ) ) {
 				$attrs = explode( ',', $settings_key['custom_attributes'] );
@@ -95,8 +107,8 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 						// Security: Sanitize attribute name (allow alphanumeric, dashes, colons)
 						$attr_name = preg_replace( '/[^a-zA-Z0-9_\-:]/', '', $attr_name );
 
-						// Security: Prevent XSS by blocking event handlers (on*) and critical attributes
-						if ( preg_match( '/^(on|href|src|formaction)/i', $attr_name ) ) {
+						// Security: Prevent XSS by blocking event handlers (on*), style, and critical attributes
+						if ( preg_match( '/^(on|href|src|formaction|style|target|rel|action)/i', $attr_name ) ) {
 							continue;
 						}
 


### PR DESCRIPTION
This PR addresses two security concerns in the `spel_button_link` helper function:

1.  **Reverse Tabnabbing Prevention:**
    -   Previously, external links (`target="_blank"`) did not automatically include `rel="noopener"`, which could allow the opened page to manipulate the original tab.
    -   **Fix:** The function now automatically adds `noopener` to the `rel` attribute for external links, merging it correctly with any existing `nofollow` setting.

2.  **Attribute Injection Hardening:**
    -   The "Custom Attributes" parsing logic previously allowed attributes like `style`, `target`, and `rel` to be injected. This could lead to:
        -   **CSS Injection:** Using `style` to alter the page appearance or execute JavaScript (in older browsers/specific contexts).
        -   **Security Bypass:** Overriding the `target` or `rel` attributes intended by the widget settings.
    -   **Fix:** The regex filter has been updated to strictly block `style`, `target`, `rel`, and `action` in addition to the existing XSS guards (`on*`, `href`, `src`, `formaction`).

These changes improve the plugin's security posture by enforcing best practices for link handling and user input sanitization without changing valid functionality.

---
*PR created automatically by Jules for task [18285151949168979452](https://jules.google.com/task/18285151949168979452) started by @mdjwel*