### PR TITLE
⚡ Bolt: Deduped animation CSS loading

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-10-24 - Unnecessary Admin File Loading
 **Learning:** `includes/Admin/Module_Settings.php` and `includes/Admin/Plugin_Installer.php` were loaded unconditionally. Even without instantiation, parsing these files adds overhead.
 **Action:** Wrapped the `require_once` calls in `if ( is_admin() )` to ensure they are only loaded when needed.
+
+## 2024-10-25 - CSS Deduplication via Dependency Aliasing
+**Learning:** Found multiple style handles enqueuing the exact same file URL, causing duplicate DOM elements.
+**Action:** Use `wp_register_style( 'main-handle', ... )` for the file, and register other handles with `src=false` and `deps=['main-handle']` to create aliases. This ensures the file is loaded once while keeping all handles valid.

--- a/includes/Frontend/Assets.php
+++ b/includes/Frontend/Assets.php
@@ -61,14 +61,14 @@ class Assets
                 'e-animation-grow',
             ];
 
-            // Deregister all styles for the handlers
+            // Register the shared animation file once
+            wp_register_style('spel-animate', SPEL_VEND . '/animation/animate.css', [], SPEL_VERSION);
+
+            // Deregister Elementor handlers and re-register them as aliases depending on spel-animate
             foreach ($handlers as $handler) {
                 wp_deregister_style($handler);
-            }
-
-            // Enqueue all handlers pointing to the same file
-            foreach ($handlers as $handler) {
-                wp_enqueue_style($handler, SPEL_VEND . '/animation/animate.css', [], SPEL_VERSION );
+                wp_register_style($handler, false, ['spel-animate']);
+                wp_enqueue_style($handler);
             }
 
         }


### PR DESCRIPTION
💡 **What:** Optimized `includes/Frontend/Assets.php` to register `animate.css` once as `spel-animate` and aliased 12 legacy Elementor animation handles to depend on it.
🎯 **Why:** The previous implementation enqueued the same `animate.css` file 12 times under different handles, causing duplicate DOM elements and potential redundant network requests.
📊 **Impact:** Reduced frontend CSS requests/tags for animations from 12 to 1 (when smooth animation is enabled).
🔬 **Measurement:** Verified with a reproduction script that `Unique Source Files` count dropped from 1 (loaded 12 times) to 1 (loaded 1 time via dependency), while all 12 handles remain enqueued/active.

---
*PR created automatically by Jules for task [3193328653937631198](https://jules.google.com/task/3193328653937631198) started by @mdjwel*