### PR TITLE
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing & Attribute Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,18 @@ When parsing custom attributes from user input:
    - Or Whitelist: Only allow `data-*`, `aria-*`, `title`, `class`, `id`.
 2. **Handle Edge Cases:** Ensure `explode` has enough parts before accessing indexes to avoid PHP notices.
 3. **Defense in Depth:** Even if the input field is restricted to admins, protecting the output function guards against privilege escalation or DB compromises.
+
+## 2024-10-24 - Reverse Tabnabbing via External Links
+**Vulnerability:**
+External links opening in a new tab (`target="_blank"`) without `rel="noopener"` allow the target page to control the parent page via `window.opener`.
+This can be used for phishing attacks where the parent page is redirected to a fake login page.
+The `spel_button_link` function relied on user input (custom attributes) or purely on `nofollow` to set the `rel` attribute, often leaving `target="_blank"` exposed.
+
+**Learning:**
+Always pair `target="_blank"` with `rel="noopener"` (or `noreferrer`).
+Do not assume `nofollow` implies `noopener`.
+When constructing attributes programmatically, use an array to collect values (e.g. `['nofollow', 'noopener']`) and implode them to ensure no conflicts or duplicates.
+
+**Prevention:**
+Enforce `rel="noopener"` automatically whenever `is_external` is detected.
+Block users from overriding critical attributes like `target` and `rel` via custom attribute fields to prevent bypassing security controls.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -81,7 +81,18 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 		if ( $is_echo ) {
 			echo ! empty( $settings_key['url'] ) ? 'href="' . esc_url( $settings_key['url'] ) . '"' : '';
 			echo $settings_key['is_external'] ? ' target="_blank"' : '';
-			echo $settings_key['nofollow'] ? ' rel="nofollow"' : '';
+
+			$rel_attributes = [];
+			if ( $settings_key['nofollow'] ) {
+				$rel_attributes[] = 'nofollow';
+			}
+			if ( $settings_key['is_external'] ) {
+				$rel_attributes[] = 'noopener';
+			}
+
+			if ( ! empty( $rel_attributes ) ) {
+				echo ' rel="' . esc_attr( implode( ' ', $rel_attributes ) ) . '"';
+			}
 
 			if ( ! empty( $settings_key['custom_attributes'] ) ) {
 				$attrs = explode( ',', $settings_key['custom_attributes'] );
@@ -96,7 +107,7 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 						$attr_name = preg_replace( '/[^a-zA-Z0-9_\-:]/', '', $attr_name );
 
 						// Security: Prevent XSS by blocking event handlers (on*) and critical attributes
-						if ( preg_match( '/^(on|href|src|formaction)/i', $attr_name ) ) {
+						if ( preg_match( '/^(on|href|src|formaction|style|target|rel|action)/i', $attr_name ) ) {
 							continue;
 						}
 


### PR DESCRIPTION
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing & Attribute Injection

**Severity:** High (Potential Phishing Vector & CSS Injection)

**Vulnerability Summary:**
1.  **Reverse Tabnabbing:** External links generated by `spel_button_link` used `target="_blank"` without consistently applying `rel="noopener"`. This allowed target pages to manipulate the parent window (`window.opener`), posing a phishing risk.
2.  **Attribute Injection:** The custom attributes parser allowed users (potentially low-privileged ones if used in widgets) to inject `style`, `target`, and `rel` attributes. This could lead to CSS injection (defacement, overlays) or bypassing of link security controls.

**Impact if Exploited:**
-   Attackers could redirect users to phishing sites after they click an external link.
-   Attackers could inject malicious CSS to deface the site or create overlay attacks.
-   Attackers could override `target` to open links in unexpected ways or remove `rel="nofollow"`.

**Fix:**
-   Modified `includes/functions.php`:
    -   Automatically append `noopener` to the `rel` attribute when `is_external` is true.
    -   Expanded the regex blocklist for custom attributes to strictly forbid `style`, `target`, `rel`, and `action`.
    -   Refactored `rel` attribute construction to use an array and `implode`, ensuring valid HTML output when both `nofollow` and `noopener` are present.

**Verification:**
-   Verified using a standalone PHP script (`repro_tabnabbing.php`) mocking WordPress functions.
-   Confirmed that `target="_blank"` links now output `rel="noopener"`.
-   Confirmed that injecting `style="background:red"`, `target="_self"`, or `rel="opener"` via custom attributes is now blocked.

---
*PR created automatically by Jules for task [10627767093363810888](https://jules.google.com/task/10627767093363810888) started by @mdjwel*