### PR TITLE
⚡ Bolt: Defer heavy theme check and extension loading to plugins_loaded

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -9,3 +9,7 @@
 ## 2024-10-24 - Unnecessary Admin File Loading
 **Learning:** `includes/Admin/Module_Settings.php` and `includes/Admin/Plugin_Installer.php` were loaded unconditionally. Even without instantiation, parsing these files adds overhead.
 **Action:** Wrapped the `require_once` calls in `if ( is_admin() )` to ensure they are only loaded when needed.
+
+## 2024-10-25 - Early Theme Initialization
+**Learning:** `wp_get_theme()` was called in the plugin's `__construct` (via `core_includes`), forcing theme initialization before `plugins_loaded`. This is premature and adds overhead on every request.
+**Action:** Moved the logic dependent on `wp_get_theme()` to the `init_plugin` method (hooked to `plugins_loaded`) and lazy-loaded the dependent classes (`Heading_Highlighted`, `Features_Badge`) only when their specific features are enabled.

--- a/spider-elements.php
+++ b/spider-elements.php
@@ -252,12 +252,6 @@ if ( ! class_exists( 'SPEL' ) ) {
 			//Action Filter
 			require_once __DIR__ . '/includes/filters.php';
 
-			$theme = wp_get_theme();
-			if ( spel_is_premium() || in_array( $theme->get( 'Name' ), [ 'jobi', 'Jobi', 'jobi-child', 'Jobi Child' ] ) ) {
-				require_once __DIR__ . '/includes/Admin/extension/Heading_Highlighted.php';
-				require_once __DIR__ . '/includes/Admin/extension/Features_Badge.php';
-			}
-
 			// Admin UI
 			if ( is_admin() ) {
 				require_once __DIR__ . '/includes/Admin/Module_Settings.php';
@@ -295,11 +289,13 @@ if ( ! class_exists( 'SPEL' ) ) {
 				// Get the feature badge status
 				$heading_highlighted = $features_opt['spel_heading_highlighted'] ?? '';
 				if ( $heading_highlighted ) {
+					require_once __DIR__ . '/includes/Admin/extension/Heading_Highlighted.php';
 					new SPEL\includes\Admin\extension\Heading_Highlighted();
 				}
 
 				$badge = $features_opt['spel_badge'] ?? '';
 				if ( $badge ) {
+					require_once __DIR__ . '/includes/Admin/extension/Features_Badge.php';
 					new SPEL\includes\Admin\extension\Features_Badge();
 				}
 


### PR DESCRIPTION
💡 **What:** Deferred the loading of `Heading_Highlighted` and `Features_Badge` extensions and the `wp_get_theme()` call from the plugin constructor to the `plugins_loaded` hook.
🎯 **Why:** `wp_get_theme()` is a relatively expensive operation that was running unconditionally on every request during plugin load (before `plugins_loaded`). This forced WordPress to initialize the theme subsystem earlier than necessary.
📊 **Impact:** Reduced bootstrap overhead on every request. Additionally, the extension files are now only parsed if their specific features are enabled, further reducing memory and CPU usage for users with these features disabled.
🔬 **Measurement:** Verified with a script that `wp_get_theme()` is no longer called during the plugin file load.

---
*PR created automatically by Jules for task [17991864568001082086](https://jules.google.com/task/17991864568001082086) started by @mdjwel*