### PR TITLE
🛡️ Sentinel: [HIGH] Fix Reverse Tabnabbing and Attribute Injection in spel_button_link

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -81,7 +81,18 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 		if ( $is_echo ) {
 			echo ! empty( $settings_key['url'] ) ? 'href="' . esc_url( $settings_key['url'] ) . '"' : '';
 			echo $settings_key['is_external'] ? ' target="_blank"' : '';
-			echo $settings_key['nofollow'] ? ' rel="nofollow"' : '';
+
+			$rel = [];
+			if ( $settings_key['nofollow'] ) {
+				$rel[] = 'nofollow';
+			}
+			if ( $settings_key['is_external'] ) {
+				$rel[] = 'noopener';
+			}
+
+			if ( ! empty( $rel ) ) {
+				echo ' rel="' . esc_attr( implode( ' ', $rel ) ) . '"';
+			}
 
 			if ( ! empty( $settings_key['custom_attributes'] ) ) {
 				$attrs = explode( ',', $settings_key['custom_attributes'] );
@@ -96,7 +107,7 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 						$attr_name = preg_replace( '/[^a-zA-Z0-9_\-:]/', '', $attr_name );
 
 						// Security: Prevent XSS by blocking event handlers (on*) and critical attributes
-						if ( preg_match( '/^(on|href|src|formaction)/i', $attr_name ) ) {
+						if ( preg_match( '/^(on|style|href|src|target|rel|formaction)/i', $attr_name ) ) {
 							continue;
 						}
 


### PR DESCRIPTION
- Blocks `style`, `target`, `rel` in custom attributes to prevent CSS injection and attribute overriding.
- Automatically adds `rel="noopener"` to external links (target="_blank") to prevent reverse tabnabbing attacks.
- Correctly combines `nofollow` and `noopener` in the `rel` attribute.
- Documented changes in `.jules/sentinel.md`.


---
*PR created automatically by Jules for task [11603405105741705012](https://jules.google.com/task/11603405105741705012) started by @mdjwel*