### PR TITLE
📋 Warden: Cleanup & Modernize Widget Rendering

### DIFF
--- a/widgets/Accordion.php
+++ b/widgets/Accordion.php
@@ -654,18 +654,17 @@ class Accordion extends Widget_Base {
     {
 
         $settings = $this->get_settings_for_display();
-		extract( $settings );
 
 		$title_tag 		  = Utils::validate_html_tag( $settings['title_tag'] ?? 'h6' );
-		$accordions       = ! empty ( $settings['accordions'] ) ? $settings['accordions'] : '';
-		$icon_align       = ! empty ( $settings['icon_align'] ) ? $settings['icon_align'] : 'right';
-		$icon_align_class = ! empty ( $icon_align == 'left' ) ? ' icon-align-left' : '';
+		$accordions       = $settings['accordions'] ?? [];
+		$icon_align       = $settings['icon_align'] ?? 'right';
+		$icon_align_class = 'left' === $icon_align ? ' icon-align-left' : '';
 
-		$is_toggle           = ! empty ( $settings['is_toggle'] ) ? $settings['is_toggle'] : '';
-		$toggle_id           = ! empty( $is_toggle == 'yes' ) ? 'id=accordionExample-' . $this->get_id() : '';
-		$toggle_bs_parent_id = ! empty( $is_toggle == 'yes' ) ? 'data-bs-parent=#accordionExample-' . $this->get_id() : '';
+		$is_toggle           = $settings['is_toggle'] ?? 'no';
+		$toggle_id           = 'yes' === $is_toggle ? 'id=accordionExample-' . $this->get_id() : '';
+		$toggle_bs_parent_id = 'yes' === $is_toggle ? 'data-bs-parent=#accordionExample-' . $this->get_id() : '';
 
 		//======================== Template Parts ========================//
-		include "templates/accordion/accordion.php";
+		include __DIR__ . "/templates/accordion/accordion.php";
 	}
 }

--- a/widgets/Counter.php
+++ b/widgets/Counter.php
@@ -435,11 +435,10 @@ class Counter extends Widget_Base {
 	 */
 	protected function render(): void {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		if ( spel_is_premium() ) {
 			include __DIR__ . "/templates/counter/counter-{$style}.php";

--- a/widgets/Icon_Box.php
+++ b/widgets/Icon_Box.php
@@ -978,12 +978,11 @@ class Icon_Box extends Widget_Base {
 
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 		$box_title_tag = Utils::validate_html_tag( $settings['box_title_tag'] ?? 'h6' );
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/Icon-box/icon-box{$style}.php";
 	}

--- a/widgets/Tabs.php
+++ b/widgets/Tabs.php
@@ -818,19 +818,23 @@ class Tabs extends Widget_Base {
     {
 
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 
 		$tabs   = $this->get_settings_for_display( 'tabs' );
 		$id_int = substr( $this->get_id_int(), 0, 3 );
 
-		$navigation_arrow_class = ! empty( $is_navigation_arrow == 'yes' ) ? ' process_tab_shortcode' : '';
-		$sticky_tab_class       = ! empty( $is_sticky_tab == 'yes' ) ? ' sticky_tab' : '';
-        $tab_auto_class         = ! empty( $is_auto_play == 'yes' ) ? ' tab_auto_play' : '';
-        $data_auto_play         = ! empty( $is_auto_play == 'yes' ) ? ' data-autoplay=yes' : '';
+        $is_navigation_arrow = $settings['is_navigation_arrow'] ?? 'no';
+        $is_sticky_tab       = $settings['is_sticky_tab'] ?? 'no';
+        $is_auto_play        = $settings['is_auto_play'] ?? 'no';
+        $is_auto_numb        = $settings['is_auto_numb'] ?? 'no';
+
+		$navigation_arrow_class = 'yes' === $is_navigation_arrow ? ' process_tab_shortcode' : '';
+		$sticky_tab_class       = 'yes' === $is_sticky_tab ? ' sticky_tab' : '';
+        $tab_auto_class         = 'yes' === $is_auto_play ? ' tab_auto_play' : '';
+        $data_auto_play         = 'yes' === $is_auto_play ? ' data-autoplay=yes' : '';
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/tabs/tab-{$style}.php";
 

--- a/widgets/Team_Carousel.php
+++ b/widgets/Team_Carousel.php
@@ -348,11 +348,10 @@ class Team_Carousel extends Widget_Base {
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 		$team_id = $this->get_id();
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/team/team-{$style}.php";
 	}

--- a/widgets/Video_Playlist.php
+++ b/widgets/Video_Playlist.php
@@ -850,11 +850,10 @@ class Video_Playlist extends Widget_Base {
 	protected function render(): void
     {
 
-        $settings = $this->get_settings();
-		extract( $settings ); //extract all settings array to variables converted to name of a key
+        $settings = $this->get_settings_for_display();
 
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		// Render the widget output on the frontend.
 		include __DIR__ . "/templates/video-playlist/video-playlist-{$style}.php";

--- a/widgets/templates/accordion/accordion.php
+++ b/widgets/templates/accordion/accordion.php
@@ -8,12 +8,12 @@ if ( ! defined( 'ABSPATH' ) ) {
 	if ( ! empty( $accordions ) ) {
         foreach ( $accordions as $index => $item ) {
             $is_collapsed_class  = $item['collapse_state'] ?? '';
-            $is_btn_collapse     = $is_collapsed_class == 'yes' ? 'collapsed ' : '';
-            $is_collapsed        = $is_collapsed_class == 'yes' ? 'true' : 'false';
+            $is_btn_collapse     = 'yes' === $is_collapsed_class ? 'collapsed ' : '';
+            $is_collapsed        = 'yes' === $is_collapsed_class ? 'true' : 'false';
             $id                  = 'toggle-' . $item['_id'] ?? '';
-            $is_show             = $is_collapsed_class == 'yes' ? ' show' : '';
+            $is_show             = 'yes' === $is_collapsed_class ? ' show' : '';
             $border_bottom_class = $index === array_key_last($accordions) ? ' border-bottom-none' : '';
-            $is_border_bottom    = !empty($settings['is_border_bottom'] == 'yes') ? '' : $border_bottom_class;
+            $is_border_bottom    = ( isset($settings['is_border_bottom']) && 'yes' === $settings['is_border_bottom'] ) ? '' : $border_bottom_class;
             ?>
             <div class="card<?php echo esc_attr($is_border_bottom) ?> accordion_inner <?php echo esc_attr( $is_btn_collapse ).esc_attr( 'accord-item-'.$item['_id'] ); ?>">
 

--- a/widgets/templates/counter/counter-2.php
+++ b/widgets/templates/counter/counter-2.php
@@ -85,7 +85,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                 requestAnimationFrame(updateCounter);
             }
 
-            //animateCounter(document.querySelector(".skill_item_two .counter"), <?php echo esc_html( $counter_value ) ?>, 1000
+            //animateCounter(document.querySelector(".skill_item_two .counter"), <?php echo esc_html( $settings['counter_value'] ) ?>, 1000
 
             window.addEventListener("scroll", function () {
                 radialProgressElements.forEach(function (element) {

--- a/widgets/templates/team/team-1.php
+++ b/widgets/templates/team/team-1.php
@@ -7,8 +7,8 @@ if (!defined('ABSPATH')) {
 <div class="expert-section-one">
     <div class="expert-slider-one slider-<?php echo esc_attr($team_id); ?>" data-rtl="<?php echo esc_attr(spel_rtl()) ?>">
         <?php
-        if (!empty($team_slider_item) && is_array($team_slider_item)) {
-            foreach ( $team_slider_item as $item ) { ?>
+        if (!empty($settings['team_slider_item']) && is_array($settings['team_slider_item'])) {
+            foreach ( $settings['team_slider_item'] as $item ) { ?>
                 <div class="item">
                     <div class="card-style-three ezd-text-center">
                         <?php

--- a/widgets/templates/team/team-2.php
+++ b/widgets/templates/team/team-2.php
@@ -5,8 +5,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 ?>
 <div class="expert-slider-two" data-rtl="<?php echo esc_attr(spel_rtl()) ?>">
 	<?php
-	if ( ! empty( $team_slider_item ) ) {
-		foreach ( $team_slider_item as $item ) { ?>
+	if ( ! empty( $settings['team_slider_item'] ) ) {
+		foreach ( $settings['team_slider_item'] as $item ) { ?>
             <div class="item">
                 <div class="card-style-eight">
 					<?php


### PR DESCRIPTION
## 📋 Warden: Cleanup & Modernize Widget Rendering

### 💡 What Changed
- Refactored `Accordion.php`, `Icon_Box.php`, `Video_Playlist.php`, `Tabs.php`, `Counter.php`, `Team_Carousel.php` to remove usage of `extract( $settings )`.
- Updated `render()` methods to explicitly define variables passed to templates or use `$settings` directly.
- Updated templates `accordion.php`, `counter-2.php`, `team-1.php`, `team-2.php` to use `$settings` array or explicitly defined variables.
- Fixed logic checks to use strict comparisons (e.g., `'yes' === $var`) and Yoda conditions.
- Standardized array syntax to `[]` in modified files.
- Ensured `include` statements use `__DIR__` for robust path resolution.

### 🎯 Why
- **WPCS Violation:** usage of `extract()` is discouraged in WordPress as it makes code harder to debug and can lead to variable collisions.
- **Maintainability:** Explicit variable definition makes it clear what data the template expects.
- **Consistency:** Standardizes coding style across widgets.

### 📊 Impact
- **Code quality:** Improved readability and maintainability.
- **Behavior:** No functional changes intended. Widgets should render exactly as before.

### 🧪 How Tested
- [x] PHP Syntax Check (`php -l`) passed on all modified files.
- [x] Manual verification of template variable usage to ensure no undefined variables.

---
*PR created automatically by Jules for task [15316313249548903765](https://jules.google.com/task/15316313249548903765) started by @mdjwel*