### PR TITLE
⚡ Bolt: Optimize spel_get_query_post_list performance

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -550,23 +550,24 @@ if ( ! function_exists( 'spel_dynamic_image' ) ) {
 if ( ! function_exists( 'spel_get_query_post_list' ) ) {
 	function spel_get_query_post_list( $post_type = 'any', $limit = -1, $search = '' ): array {
 		$args = [
-			'post_type'      => $post_type,
-			'post_status'    => 'publish',
-			'posts_per_page' => $limit,
-			's'              => $search, // Search term
+			'post_type'              => $post_type,
+			'post_status'            => 'publish',
+			'posts_per_page'         => $limit,
+			's'                      => $search, // Search term
+			'no_found_rows'          => true, // Optimization: Skip pagination calculation
+			'update_post_meta_cache' => false, // Optimization: We only need ID and Title
+			'update_post_term_cache' => false, // Optimization: We only need ID and Title
+			'ignore_sticky_posts'    => true, // Optimization: Ignore sticky posts logic
 		];
 
 		$query = new WP_Query( $args );
 
 		$data = [];
-		if ( $query->have_posts() ) {
-			while ( $query->have_posts() ) {
-				$query->the_post();
-				$data[ get_the_ID() ] = get_the_title();
+		if ( ! empty( $query->posts ) ) {
+			foreach ( $query->posts as $post ) {
+				$data[ $post->ID ] = get_the_title( $post );
 			}
 		}
-
-		wp_reset_postdata(); // Reset post data after custom query
 
 		return $data;
 	}


### PR DESCRIPTION
💡 **What:** Optimized `spel_get_query_post_list` in `includes/functions.php` by adding performance flags to `WP_Query` and refactoring the iteration loop.
🎯 **Why:** The function is used to populate dropdowns (e.g. template selection) but was performing a full `WP_Query` with pagination calculation (`SQL_CALC_FOUND_ROWS`) and cache updates (`update_post_meta_cache`, `update_post_term_cache`), which are unnecessary when only ID and Title are needed. It also used a `while(have_posts())` loop that incurs overhead by setting up the global `$post` object for each item.
📊 **Impact:** Reduced database load by skipping found rows calculation and cache updates. Reduced PHP overhead by iterating directly over the posts array.
🔬 **Measurement:** Verified via a standalone script (`verify_optimization.php`) that the correct optimization flags (`no_found_rows`, `update_post_meta_cache`, `update_post_term_cache`, `ignore_sticky_posts`) are passed to `WP_Query` and that the function continues to return the correct `ID => Title` map.

---
*PR created automatically by Jules for task [7466064481958428544](https://jules.google.com/task/7466064481958428544) started by @mdjwel*