### PR TITLE
🛡️ Sentinel: [MEDIUM] Fix Reverse Tabnabbing and Attribute Injection

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,19 @@ When parsing custom attributes from user input:
    - Or Whitelist: Only allow `data-*`, `aria-*`, `title`, `class`, `id`.
 2. **Handle Edge Cases:** Ensure `explode` has enough parts before accessing indexes to avoid PHP notices.
 3. **Defense in Depth:** Even if the input field is restricted to admins, protecting the output function guards against privilege escalation or DB compromises.
+
+## 2024-05-25 - Reverse Tabnabbing and Attribute Override via Custom Attributes
+**Vulnerability:**
+The `spel_button_link` function generated `target="_blank"` for external links without adding `rel="noopener"`, exposing users to Reverse Tabnabbing attacks (phishing via `window.opener`).
+Additionally, the function allowed `custom_attributes` to inject `target` and `rel`, potentially overriding the secure defaults or removing `nofollow`.
+It also allowed `style` attribute injection, enabling CSS-based attacks.
+
+**Learning:**
+1.  **Implicit Trust in Defaults:** Developers often assume `target="_blank"` is safe or that browsers handle it, but explicit `rel="noopener"` is required for full security.
+2.  **Attribute Overriding:** When merging "Custom Attributes" with standard settings, users can inadvertently (or maliciously) override critical security attributes like `rel` or `target` if they are not explicitly blocked.
+3.  **Inconsistent Sanitization:** Different helper functions (`spel_el_image` vs `spel_button_link`) had different blacklists, leaving one vulnerable while the other was secure.
+
+**Prevention:**
+1.  **Enforce Noopener:** Always append `noopener` to `rel` when `target="_blank"` is used.
+2.  **Strict Blocking:** In custom attribute parsers, explicitly block `target`, `rel`, and `style` in addition to XSS vectors (`on*`, `href`, `src`).
+3.  **Centralize Logic:** Use a shared function for attribute generation to ensure consistent security policies across all widgets.

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -81,7 +81,20 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 		if ( $is_echo ) {
 			echo ! empty( $settings_key['url'] ) ? 'href="' . esc_url( $settings_key['url'] ) . '"' : '';
 			echo $settings_key['is_external'] ? ' target="_blank"' : '';
-			echo $settings_key['nofollow'] ? ' rel="nofollow"' : '';
+
+			$rel = [];
+
+			if ( ! empty( $settings_key['nofollow'] ) ) {
+				$rel[] = 'nofollow';
+			}
+
+			if ( ! empty( $settings_key['is_external'] ) ) {
+				$rel[] = 'noopener';
+			}
+
+			if ( ! empty( $rel ) ) {
+				echo ' rel="' . esc_attr( implode( ' ', $rel ) ) . '"';
+			}
 
 			if ( ! empty( $settings_key['custom_attributes'] ) ) {
 				$attrs = explode( ',', $settings_key['custom_attributes'] );
@@ -96,7 +109,7 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 						$attr_name = preg_replace( '/[^a-zA-Z0-9_\-:]/', '', $attr_name );
 
 						// Security: Prevent XSS by blocking event handlers (on*) and critical attributes
-						if ( preg_match( '/^(on|href|src|formaction)/i', $attr_name ) ) {
+						if ( preg_match( '/^(on|href|src|formaction|style|target|rel)/i', $attr_name ) ) {
 							continue;
 						}
 


### PR DESCRIPTION
This PR addresses a medium-severity security issue in the `spel_button_link` function found in `includes/functions.php`.

**Security Improvements:**
1.  **Reverse Tabnabbing Protection:** Previously, external links (`target="_blank"`) were generated without `rel="noopener"`. This exposed users to Reverse Tabnabbing attacks where a malicious target page could manipulate the originating page via `window.opener`. This PR ensures `rel="noopener"` is always added for external links.
2.  **Attribute Injection Hardening:** The "Custom Attributes" parser allowed users to inject `style`, `target`, and `rel` attributes. This could be used to:
    *   Override the intended `target` or `rel` settings (e.g., removing `nofollow`).
    *   Inject malicious CSS via the `style` attribute.
    
    The fix explicitly blocks `style`, `target`, and `rel` in the custom attribute parsing loop, matching the stricter security logic already present in `spel_el_image`.

**Verification:**
A reproduction script `repro_vuln.php` (created and deleted during development) confirmed that:
*   `rel="noopener"` is now correctly appended to external links.
*   Injected `style`, `target`, and `rel` attributes are successfully stripped from the output.

**Backward Compatibility:**
This change is backward compatible. It only restricts potentially dangerous or overriding attributes that should not be set via the generic "Custom Attributes" field. The `nofollow` functionality is preserved and correctly merged with `noopener`.

---
*PR created automatically by Jules for task [10557393850984507861](https://jules.google.com/task/10557393850984507861) started by @mdjwel*