### PR TITLE
📋 Warden: Refactor Widget Render Methods for Security and Maintainability

### DIFF
--- a/.warden/journal.md
+++ b/.warden/journal.md
@@ -9,3 +9,7 @@
 ## 2025-01-23 - Filters File Responsibility
 **Learning:** `includes/filters.php` is misnamed; it contains admin controller logic (form handling on `admin_init`).
 **Action:** Be aware that "filter" changes might actually involve admin form processing logic.
+
+## 2025-01-23 - Widget Rendering Pattern
+**Learning:** Widgets heavily relied on `extract( $settings )`, polluting the symbol table and obscuring variable origins. Render methods have been refactored to use direct array access (e.g., `$settings['key']`).
+**Action:** When adding or modifying widgets, avoid `extract()`. Explicitly define variables derived from settings to maintain clarity and security.

--- a/widgets/Accordion.php
+++ b/widgets/Accordion.php
@@ -654,18 +654,17 @@ class Accordion extends Widget_Base {
     {
 
         $settings = $this->get_settings_for_display();
-		extract( $settings );
 
 		$title_tag 		  = Utils::validate_html_tag( $settings['title_tag'] ?? 'h6' );
-		$accordions       = ! empty ( $settings['accordions'] ) ? $settings['accordions'] : '';
+		$accordions       = ! empty ( $settings['accordions'] ) ? $settings['accordions'] : [];
 		$icon_align       = ! empty ( $settings['icon_align'] ) ? $settings['icon_align'] : 'right';
-		$icon_align_class = ! empty ( $icon_align == 'left' ) ? ' icon-align-left' : '';
+		$icon_align_class = ( 'left' === $icon_align ) ? ' icon-align-left' : '';
 
 		$is_toggle           = ! empty ( $settings['is_toggle'] ) ? $settings['is_toggle'] : '';
-		$toggle_id           = ! empty( $is_toggle == 'yes' ) ? 'id=accordionExample-' . $this->get_id() : '';
-		$toggle_bs_parent_id = ! empty( $is_toggle == 'yes' ) ? 'data-bs-parent=#accordionExample-' . $this->get_id() : '';
+		$toggle_id           = ( 'yes' === $is_toggle ) ? 'id=accordionExample-' . $this->get_id() : '';
+		$toggle_bs_parent_id = ( 'yes' === $is_toggle ) ? 'data-bs-parent=#accordionExample-' . $this->get_id() : '';
 
 		//======================== Template Parts ========================//
-		include "templates/accordion/accordion.php";
+		include __DIR__ . "/templates/accordion/accordion.php";
 	}
 }

--- a/widgets/Counter.php
+++ b/widgets/Counter.php
@@ -435,7 +435,6 @@ class Counter extends Widget_Base {
 	 */
 	protected function render(): void {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion

--- a/widgets/Icon_Box.php
+++ b/widgets/Icon_Box.php
@@ -978,7 +978,7 @@ class Icon_Box extends Widget_Base {
 
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
+
 		$box_title_tag = Utils::validate_html_tag( $settings['box_title_tag'] ?? 'h6' );
 
 		//================= Template Parts =================//

--- a/widgets/Tabs.php
+++ b/widgets/Tabs.php
@@ -818,15 +818,19 @@ class Tabs extends Widget_Base {
     {
 
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 
-		$tabs   = $this->get_settings_for_display( 'tabs' );
+		$is_navigation_arrow = $settings['is_navigation_arrow'] ?? 'no';
+		$is_sticky_tab       = $settings['is_sticky_tab'] ?? 'no';
+		$is_auto_play        = $settings['is_auto_play'] ?? 'no';
+		$is_auto_numb        = $settings['is_auto_numb'] ?? 'no';
+
+		$tabs   = $settings['tabs'] ?? [];
 		$id_int = substr( $this->get_id_int(), 0, 3 );
 
-		$navigation_arrow_class = ! empty( $is_navigation_arrow == 'yes' ) ? ' process_tab_shortcode' : '';
-		$sticky_tab_class       = ! empty( $is_sticky_tab == 'yes' ) ? ' sticky_tab' : '';
-        $tab_auto_class         = ! empty( $is_auto_play == 'yes' ) ? ' tab_auto_play' : '';
-        $data_auto_play         = ! empty( $is_auto_play == 'yes' ) ? ' data-autoplay=yes' : '';
+		$navigation_arrow_class = ( 'yes' === $is_navigation_arrow ) ? ' process_tab_shortcode' : '';
+		$sticky_tab_class       = ( 'yes' === $is_sticky_tab ) ? ' sticky_tab' : '';
+        $tab_auto_class         = ( 'yes' === $is_auto_play ) ? ' tab_auto_play' : '';
+        $data_auto_play         = ( 'yes' === $is_auto_play ) ? ' data-autoplay=yes' : '';
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion

--- a/widgets/Team_Carousel.php
+++ b/widgets/Team_Carousel.php
@@ -348,8 +348,10 @@ class Team_Carousel extends Widget_Base {
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
+
 		$team_id = $this->get_id();
+		$team_slider_item = $settings['team_slider_item'] ?? [];
+
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
 		$allowed_styles = array( '1', '2' );

--- a/widgets/Video_Playlist.php
+++ b/widgets/Video_Playlist.php
@@ -851,7 +851,6 @@ class Video_Playlist extends Widget_Base {
     {
 
         $settings = $this->get_settings();
-		extract( $settings ); //extract all settings array to variables converted to name of a key
 
 		// Whitelist valid style values to prevent Local File Inclusion
 		$allowed_styles = array( '1', '2' );

--- a/widgets/Video_Popup.php
+++ b/widgets/Video_Popup.php
@@ -425,7 +425,6 @@ class Video_Popup extends Widget_Base {
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of a key
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion

--- a/widgets/templates/counter/counter-2.php
+++ b/widgets/templates/counter/counter-2.php
@@ -85,7 +85,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                 requestAnimationFrame(updateCounter);
             }
 
-            //animateCounter(document.querySelector(".skill_item_two .counter"), <?php echo esc_html( $counter_value ) ?>, 1000
+            //animateCounter(document.querySelector(".skill_item_two .counter"), <?php echo esc_html( $settings['counter_value'] ) ?>, 1000
 
             window.addEventListener("scroll", function () {
                 radialProgressElements.forEach(function (element) {


### PR DESCRIPTION
This PR refactors several Elementor widgets to remove the use of `extract( $settings )` in their `render()` methods. 

**Why:**
- `extract()` pollutes the symbol table and makes it difficult to trace variable origins.
- It can lead to unintentional variable overwrites.
- Removing it improves code clarity, maintainability, and security.
- The PR also fixes some non-standard logic checks (e.g., `!empty($var == 'val')`) and enforces strict comparisons.

**Changes:**
- Refactored `Accordion`, `Icon_Box`, `Tabs`, `Video_Popup`, `Counter`, `Team_Carousel`, and `Video_Playlist` widgets.
- Explicitly defined variables required by templates or updated templates to use `$settings` directly.
- Standardized array syntax and comparisons in modified files.

**Testing:**
- Verified PHP syntax using `php -l` on all modified files and their templates.
- Verified that templates use `$settings` or explicitly defined variables.


---
*PR created automatically by Jules for task [10184455361852797551](https://jules.google.com/task/10184455361852797551) started by @mdjwel*