### PR TITLE
Refactor widget render methods to remove extract() and improve code quality

### DIFF
--- a/widgets/Accordion.php
+++ b/widgets/Accordion.php
@@ -653,19 +653,18 @@ class Accordion extends Widget_Base {
 	protected function render(): void
     {
 
-        $settings = $this->get_settings_for_display();
-		extract( $settings );
+		$settings = $this->get_settings_for_display();
 
-		$title_tag 		  = Utils::validate_html_tag( $settings['title_tag'] ?? 'h6' );
-		$accordions       = ! empty ( $settings['accordions'] ) ? $settings['accordions'] : '';
-		$icon_align       = ! empty ( $settings['icon_align'] ) ? $settings['icon_align'] : 'right';
-		$icon_align_class = ! empty ( $icon_align == 'left' ) ? ' icon-align-left' : '';
+		$title_tag        = Utils::validate_html_tag( $settings['title_tag'] ?? 'h6' );
+		$accordions       = $settings['accordions'] ?? [];
+		$icon_align       = $settings['icon_align'] ?? 'right';
+		$icon_align_class = ( 'left' === $icon_align ) ? ' icon-align-left' : '';
 
-		$is_toggle           = ! empty ( $settings['is_toggle'] ) ? $settings['is_toggle'] : '';
-		$toggle_id           = ! empty( $is_toggle == 'yes' ) ? 'id=accordionExample-' . $this->get_id() : '';
-		$toggle_bs_parent_id = ! empty( $is_toggle == 'yes' ) ? 'data-bs-parent=#accordionExample-' . $this->get_id() : '';
+		$is_toggle           = $settings['is_toggle'] ?? '';
+		$toggle_id           = ( 'yes' === $is_toggle ) ? 'id=accordionExample-' . $this->get_id() : '';
+		$toggle_bs_parent_id = ( 'yes' === $is_toggle ) ? 'data-bs-parent=#accordionExample-' . $this->get_id() : '';
 
 		//======================== Template Parts ========================//
-		include "templates/accordion/accordion.php";
+		include __DIR__ . '/templates/accordion/accordion.php';
 	}
 }

--- a/widgets/Counter.php
+++ b/widgets/Counter.php
@@ -435,11 +435,11 @@ class Counter extends Widget_Base {
 	 */
 	protected function render(): void {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
+		$counter_value = $settings['counter_value'] ?? 0;
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		if ( spel_is_premium() ) {
 			include __DIR__ . "/templates/counter/counter-{$style}.php";

--- a/widgets/Icon_Box.php
+++ b/widgets/Icon_Box.php
@@ -978,12 +978,11 @@ class Icon_Box extends Widget_Base {
 
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 		$box_title_tag = Utils::validate_html_tag( $settings['box_title_tag'] ?? 'h6' );
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/Icon-box/icon-box{$style}.php";
 	}

--- a/widgets/Tabs.php
+++ b/widgets/Tabs.php
@@ -818,19 +818,23 @@ class Tabs extends Widget_Base {
     {
 
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 
-		$tabs   = $this->get_settings_for_display( 'tabs' );
+		$is_navigation_arrow = $settings['is_navigation_arrow'] ?? '';
+		$is_sticky_tab       = $settings['is_sticky_tab'] ?? '';
+		$is_auto_play        = $settings['is_auto_play'] ?? '';
+		$is_auto_numb        = $settings['is_auto_numb'] ?? '';
+
+		$tabs   = $settings['tabs'] ?? [];
 		$id_int = substr( $this->get_id_int(), 0, 3 );
 
-		$navigation_arrow_class = ! empty( $is_navigation_arrow == 'yes' ) ? ' process_tab_shortcode' : '';
-		$sticky_tab_class       = ! empty( $is_sticky_tab == 'yes' ) ? ' sticky_tab' : '';
-        $tab_auto_class         = ! empty( $is_auto_play == 'yes' ) ? ' tab_auto_play' : '';
-        $data_auto_play         = ! empty( $is_auto_play == 'yes' ) ? ' data-autoplay=yes' : '';
+		$navigation_arrow_class = ( 'yes' === $is_navigation_arrow ) ? ' process_tab_shortcode' : '';
+		$sticky_tab_class       = ( 'yes' === $is_sticky_tab ) ? ' sticky_tab' : '';
+        $tab_auto_class         = ( 'yes' === $is_auto_play ) ? ' tab_auto_play' : '';
+        $data_auto_play         = ( 'yes' === $is_auto_play ) ? ' data-autoplay=yes' : '';
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/tabs/tab-{$style}.php";
 

--- a/widgets/Team_Carousel.php
+++ b/widgets/Team_Carousel.php
@@ -348,11 +348,11 @@ class Team_Carousel extends Widget_Base {
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
+		$team_slider_item = $settings['team_slider_item'] ?? [];
 		$team_id = $this->get_id();
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/team/team-{$style}.php";
 	}

--- a/widgets/Video_Playlist.php
+++ b/widgets/Video_Playlist.php
@@ -851,10 +851,9 @@ class Video_Playlist extends Widget_Base {
     {
 
         $settings = $this->get_settings();
-		extract( $settings ); //extract all settings array to variables converted to name of a key
 
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		// Render the widget output on the frontend.
 		include __DIR__ . "/templates/video-playlist/video-playlist-{$style}.php";

--- a/widgets/Video_Popup.php
+++ b/widgets/Video_Popup.php
@@ -425,11 +425,10 @@ class Video_Popup extends Widget_Base {
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of a key
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/video-popup/video-popup-{$style}.php";
 	}


### PR DESCRIPTION
## 📋 Warden: Widget Code Cleanup and Standardization

### 💡 What Changed
- Refactored `render()` methods in 7 widgets:
    - `Accordion.php`
    - `Counter.php`
    - `Icon_Box.php`
    - `Tabs.php`
    - `Team_Carousel.php`
    - `Video_Playlist.php`
    - `Video_Popup.php`
- Removed `extract( $settings );` calls.
- Replaced ambiguous logic `! empty( $var == 'value' )` with strict Yoda conditions (e.g., `'yes' === $var`).
- Standardized array syntax (`array()` -> `[]`) in touched code blocks.
- Explicitly defined variables required by included templates (e.g., `$counter_value`, `$is_auto_play`).
- Updated `include` statements to use `__DIR__` for absolute path resolution.

### 🎯 Why
- **WPCS & Best Practices:** `extract()` is discouraged in WordPress development (and general PHP) because it obfuscates variable origins and can overwrite local variables unpredictably.
- **Logic Fixes:** `! empty( $var == 'value' )` is a common anti-pattern where `empty(false)` returns true, causing potential logic errors (though mostly benign here, it's confusing). Strict comparison is safer and clearer.
- **Modernization:** Standardizing on short array syntax `[]` aligns with modern PHP standards used elsewhere in the project.

### 📊 Impact
- **Code quality:** Improved readability, static analysis capability, and maintainability.
- **Behavior:** No functional changes intended. Widgets should render exactly as before.

### 🧪 How Tested
- [x] PHP syntax check (`php -l`) passed on all modified files.
- [x] Manual code review verified that variables used in templates are correctly defined in the `render()` method scope.

### 🧩 Compatibility Notes
- PHP: 7.4+ (Project requirement is 7.4, consistent with `[]` syntax).
- WordPress: Standard compliance.

### 📋 Checklist
- [x] No breaking changes to public hooks/filters
- [x] No functional/behavior changes (style/quality only)
- [x] Changes scoped to stated theme only


---
*PR created automatically by Jules for task [11596655556056718190](https://jules.google.com/task/11596655556056718190) started by @mdjwel*