### PR TITLE
⚡ Bolt: Optimize spel_get_query_post_list WP_Query performance

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -550,23 +550,24 @@ if ( ! function_exists( 'spel_dynamic_image' ) ) {
 if ( ! function_exists( 'spel_get_query_post_list' ) ) {
 	function spel_get_query_post_list( $post_type = 'any', $limit = -1, $search = '' ): array {
 		$args = [
-			'post_type'      => $post_type,
-			'post_status'    => 'publish',
-			'posts_per_page' => $limit,
-			's'              => $search, // Search term
+			'post_type'              => $post_type,
+			'post_status'            => 'publish',
+			'posts_per_page'         => $limit,
+			's'                      => $search, // Search term
+			'no_found_rows'          => true,
+			'ignore_sticky_posts'    => true,
+			'update_post_term_cache' => false,
+			'update_post_meta_cache' => false,
 		];
 
 		$query = new WP_Query( $args );
 
 		$data = [];
-		if ( $query->have_posts() ) {
-			while ( $query->have_posts() ) {
-				$query->the_post();
-				$data[ get_the_ID() ] = get_the_title();
+		if ( ! empty( $query->posts ) ) {
+			foreach ( $query->posts as $post ) {
+				$data[ $post->ID ] = get_the_title( $post );
 			}
 		}
-
-		wp_reset_postdata(); // Reset post data after custom query
 
 		return $data;
 	}


### PR DESCRIPTION
* 💡 **What:** Optimized `spel_get_query_post_list` in `includes/functions.php`.
* 🎯 **Why:** The function was running a full `WP_Query` with `the_post()` loop to fetch all posts of a type for a dropdown, causing unnecessary DB load and object hydration overhead.
* 📊 **Impact:** Reduced DB queries (disabled meta/term caches, disabled row counting) and memory usage (avoided global post setup) for list retrieval.
* 🔬 **Measurement:** Verified with a mock script `test_vuln.php` confirming correct initialization of `WP_Query` with optimization flags.

---
*PR created automatically by Jules for task [18269798735515528965](https://jules.google.com/task/18269798735515528965) started by @mdjwel*