### PR TITLE
🛡️ Sentinel: Remove unsafe extract($settings) usage in widgets

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,22 @@ When parsing custom attributes from user input:
    - Or Whitelist: Only allow `data-*`, `aria-*`, `title`, `class`, `id`.
 2. **Handle Edge Cases:** Ensure `explode` has enough parts before accessing indexes to avoid PHP notices.
 3. **Defense in Depth:** Even if the input field is restricted to admins, protecting the output function guards against privilege escalation or DB compromises.
+
+## 2024-05-23 - `extract($settings)` Pollution in Elementor Widgets
+**Vulnerability:**
+Extensive use of `extract($settings)` in widget `render()` methods was observed.
+This PHP function imports variables from an array into the current symbol table.
+Since `$settings` is derived from user input (Elementor controls), this theoretically allows variable overwriting.
+While often mitigated by subsequent variable re-assignment, it introduces:
+1.  **Fragility:** New controls added later might accidentally overwrite internal logic variables.
+2.  **Opacity:** It is unclear where variables like `$title` or `$is_active` come from (settings or internal logic).
+3.  **Security Risk:** In complex methods, it can lead to logic bypasses if internal variables are defined *before* `extract()`.
+
+**Learning:**
+Elementor widget boilerplate often includes `extract($settings)`. Developers copy this pattern without realizing it defeats the purpose of explicit variable definition and creates a "magic" scope.
+It is almost always redundant because templates usually access `$settings` directly or use specific variables prepared in `render()`.
+
+**Prevention:**
+1.  **Ban `extract()`:** Do not use `extract()` on user input.
+2.  **Explicit Definition:** Define variables explicitly: `$title = $settings['title'] ?? '';`.
+3.  **Direct Access:** Use `$settings['key']` directly in templates for simple values.

--- a/widgets/Accordion.php
+++ b/widgets/Accordion.php
@@ -654,7 +654,6 @@ class Accordion extends Widget_Base {
     {
 
         $settings = $this->get_settings_for_display();
-		extract( $settings );
 
 		$title_tag 		  = Utils::validate_html_tag( $settings['title_tag'] ?? 'h6' );
 		$accordions       = ! empty ( $settings['accordions'] ) ? $settings['accordions'] : '';

--- a/widgets/Counter.php
+++ b/widgets/Counter.php
@@ -435,7 +435,6 @@ class Counter extends Widget_Base {
 	 */
 	protected function render(): void {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion

--- a/widgets/Icon_Box.php
+++ b/widgets/Icon_Box.php
@@ -978,7 +978,6 @@ class Icon_Box extends Widget_Base {
 
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 		$box_title_tag = Utils::validate_html_tag( $settings['box_title_tag'] ?? 'h6' );
 
 		//================= Template Parts =================//

--- a/widgets/Tabs.php
+++ b/widgets/Tabs.php
@@ -818,7 +818,10 @@ class Tabs extends Widget_Base {
     {
 
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
+		$is_navigation_arrow = $settings['is_navigation_arrow'] ?? '';
+		$is_sticky_tab       = $settings['is_sticky_tab'] ?? '';
+		$is_auto_play        = $settings['is_auto_play'] ?? '';
+		$is_auto_numb        = $settings['is_auto_numb'] ?? '';
 
 		$tabs   = $this->get_settings_for_display( 'tabs' );
 		$id_int = substr( $this->get_id_int(), 0, 3 );

--- a/widgets/Team_Carousel.php
+++ b/widgets/Team_Carousel.php
@@ -348,7 +348,7 @@ class Team_Carousel extends Widget_Base {
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
+		$team_slider_item = $settings['team_slider_item'] ?? [];
 		$team_id = $this->get_id();
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion

--- a/widgets/Video_Playlist.php
+++ b/widgets/Video_Playlist.php
@@ -851,7 +851,6 @@ class Video_Playlist extends Widget_Base {
     {
 
         $settings = $this->get_settings();
-		extract( $settings ); //extract all settings array to variables converted to name of a key
 
 		// Whitelist valid style values to prevent Local File Inclusion
 		$allowed_styles = array( '1', '2' );

--- a/widgets/Video_Popup.php
+++ b/widgets/Video_Popup.php
@@ -425,7 +425,6 @@ class Video_Popup extends Widget_Base {
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of a key
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion

--- a/widgets/templates/counter/counter-2.php
+++ b/widgets/templates/counter/counter-2.php
@@ -85,7 +85,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                 requestAnimationFrame(updateCounter);
             }
 
-            //animateCounter(document.querySelector(".skill_item_two .counter"), <?php echo esc_html( $counter_value ) ?>, 1000
+            //animateCounter(document.querySelector(".skill_item_two .counter"), <?php echo esc_html( $settings['counter_value'] ) ?>, 1000
 
             window.addEventListener("scroll", function () {
                 radialProgressElements.forEach(function (element) {


### PR DESCRIPTION
### Security Enhancement: Remove `extract($settings)`

This PR removes the unsafe usage of `extract($settings)` across multiple Elementor widgets.

**Rationale:**
Using `extract()` on user-controlled input (like `$settings` in Elementor widgets) imports variables into the local scope, potentially overwriting internal variables. This is a known security weakness (CWE-621) and a bad coding practice that reduces code clarity and stability.

**Changes:**
1.  **Widgets Refactored:**
    *   `widgets/Accordion.php`
    *   `widgets/Icon_Box.php`
    *   `widgets/Tabs.php`
    *   `widgets/Video_Popup.php`
    *   `widgets/Counter.php`
    *   `widgets/Team_Carousel.php`
    *   `widgets/Video_Playlist.php`

2.  **Specific Fixes:**
    *   In `Tabs.php`: Explicitly defined `$is_navigation_arrow`, `$is_sticky_tab`, `$is_auto_play`, `$is_auto_numb` which were previously relying on `extract()`.
    *   In `Team_Carousel.php`: Explicitly defined `$team_slider_item`.
    *   In `widgets/templates/counter/counter-2.php`: Fixed a potential "Undefined variable" warning by replacing `$counter_value` with `$settings['counter_value']`.

**Verification:**
*   Ran `php -l` on all modified files to ensure no syntax errors were introduced.
*   Manually verified that templates use `$settings` or the explicitly defined variables.

**Risk:**
Low. The changes are structural refactors to use explicit variable access. Backwards compatibility is maintained as the logic remains the same.


---
*PR created automatically by Jules for task [5448855847876076352](https://jules.google.com/task/5448855847876076352) started by @mdjwel*