### PR TITLE
Refactor widgets and fix spel_readable_number logic

### DIFF
--- a/includes/functions.php
+++ b/includes/functions.php
@@ -27,7 +27,7 @@ function spel_unlock_docy_theme(): bool {
 }
 
 function spel_rtl(): string {
-		return is_rtl() ? 'true' : 'false';
+	return is_rtl() ? 'true' : 'false';
 }
 
 /**
@@ -688,11 +688,11 @@ if ( ! function_exists( 'spel_readable_number' ) ) {
 		$suffix = strtolower( $suffix );
 
 		$multipliers = [
-			'p' => 1024,
-			't' => 1024,
-			'g' => 1024,
-			'm' => 1024,
-			'k' => 1024,
+			'p' => 1125899906842624, // 1024^5
+			't' => 1099511627776,    // 1024^4
+			'g' => 1073741824,       // 1024^3
+			'm' => 1048576,          // 1024^2
+			'k' => 1024,             // 1024^1
 		];
 
 		// Check if the suffix is a valid multiplier

--- a/widgets/Accordion.php
+++ b/widgets/Accordion.php
@@ -653,17 +653,16 @@ class Accordion extends Widget_Base {
 	protected function render(): void
     {
 
-        $settings = $this->get_settings_for_display();
-		extract( $settings );
+		$settings = $this->get_settings_for_display();
 
-		$title_tag 		  = Utils::validate_html_tag( $settings['title_tag'] ?? 'h6' );
-		$accordions       = ! empty ( $settings['accordions'] ) ? $settings['accordions'] : '';
-		$icon_align       = ! empty ( $settings['icon_align'] ) ? $settings['icon_align'] : 'right';
-		$icon_align_class = ! empty ( $icon_align == 'left' ) ? ' icon-align-left' : '';
+		$title_tag        = Utils::validate_html_tag( $settings['title_tag'] ?? 'h6' );
+		$accordions       = $settings['accordions'] ?? [];
+		$icon_align       = $settings['icon_align'] ?? 'right';
+		$icon_align_class = ( 'left' === $icon_align ) ? ' icon-align-left' : '';
 
-		$is_toggle           = ! empty ( $settings['is_toggle'] ) ? $settings['is_toggle'] : '';
-		$toggle_id           = ! empty( $is_toggle == 'yes' ) ? 'id=accordionExample-' . $this->get_id() : '';
-		$toggle_bs_parent_id = ! empty( $is_toggle == 'yes' ) ? 'data-bs-parent=#accordionExample-' . $this->get_id() : '';
+		$is_toggle           = $settings['is_toggle'] ?? '';
+		$toggle_id           = ( 'yes' === $is_toggle ) ? 'id=accordionExample-' . $this->get_id() : '';
+		$toggle_bs_parent_id = ( 'yes' === $is_toggle ) ? 'data-bs-parent=#accordionExample-' . $this->get_id() : '';
 
 		//======================== Template Parts ========================//
 		include "templates/accordion/accordion.php";

--- a/widgets/Counter.php
+++ b/widgets/Counter.php
@@ -435,11 +435,10 @@ class Counter extends Widget_Base {
 	 */
 	protected function render(): void {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		if ( spel_is_premium() ) {
 			include __DIR__ . "/templates/counter/counter-{$style}.php";

--- a/widgets/Icon_Box.php
+++ b/widgets/Icon_Box.php
@@ -978,12 +978,11 @@ class Icon_Box extends Widget_Base {
 
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 		$box_title_tag = Utils::validate_html_tag( $settings['box_title_tag'] ?? 'h6' );
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/Icon-box/icon-box{$style}.php";
 	}

--- a/widgets/Tabs.php
+++ b/widgets/Tabs.php
@@ -818,19 +818,24 @@ class Tabs extends Widget_Base {
     {
 
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 
-		$tabs   = $this->get_settings_for_display( 'tabs' );
+		$tabs   = $settings['tabs'] ?? [];
 		$id_int = substr( $this->get_id_int(), 0, 3 );
 
-		$navigation_arrow_class = ! empty( $is_navigation_arrow == 'yes' ) ? ' process_tab_shortcode' : '';
-		$sticky_tab_class       = ! empty( $is_sticky_tab == 'yes' ) ? ' sticky_tab' : '';
-        $tab_auto_class         = ! empty( $is_auto_play == 'yes' ) ? ' tab_auto_play' : '';
-        $data_auto_play         = ! empty( $is_auto_play == 'yes' ) ? ' data-autoplay=yes' : '';
+		// Extract settings for template use
+		$is_navigation_arrow = $settings['is_navigation_arrow'] ?? 'no';
+		$is_sticky_tab       = $settings['is_sticky_tab'] ?? 'no';
+		$is_auto_play        = $settings['is_auto_play'] ?? 'no';
+		$is_auto_numb        = $settings['is_auto_numb'] ?? 'no';
+
+		$navigation_arrow_class = ( 'yes' === $is_navigation_arrow ) ? ' process_tab_shortcode' : '';
+		$sticky_tab_class       = ( 'yes' === $is_sticky_tab ) ? ' sticky_tab' : '';
+		$tab_auto_class         = ( 'yes' === $is_auto_play ) ? ' tab_auto_play' : '';
+		$data_auto_play         = ( 'yes' === $is_auto_play ) ? ' data-autoplay=yes' : '';
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/tabs/tab-{$style}.php";
 

--- a/widgets/Video_Popup.php
+++ b/widgets/Video_Popup.php
@@ -425,11 +425,10 @@ class Video_Popup extends Widget_Base {
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of a key
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
+		$allowed_styles = [ '1', '2' ];
 		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/video-popup/video-popup-{$style}.php";
 	}

--- a/widgets/templates/counter/counter-2.php
+++ b/widgets/templates/counter/counter-2.php
@@ -85,7 +85,7 @@ if ( ! defined( 'ABSPATH' ) ) {
                 requestAnimationFrame(updateCounter);
             }
 
-            //animateCounter(document.querySelector(".skill_item_two .counter"), <?php echo esc_html( $counter_value ) ?>, 1000
+            //animateCounter(document.querySelector(".skill_item_two .counter"), <?php echo esc_html( $settings['counter_value'] ) ?>, 1000
 
             window.addEventListener("scroll", function () {
                 radialProgressElements.forEach(function (element) {


### PR DESCRIPTION
##  Warden: Refactor Widgets and Fix Logic

### 💡 What Changed
- **`includes/functions.php`**: Fixed `spel_readable_number` to use correct powers of 1024 for KB, MB, GB, TB, PB. Fixed indentation in `spel_rtl`.
- **`widgets/Accordion.php`**: Removed `extract($settings)`. Fixed `!empty($v == 'val')` logic. Explicitly defined variables used in template.
- **`widgets/Icon_Box.php`**: Removed `extract($settings)`. Standardized array syntax. Confirmed templates use `$settings`.
- **`widgets/Tabs.php`**: Removed `extract($settings)`. Explicitly defined `$is_auto_play`, `$is_navigation_arrow`, etc. Fixed logic and array syntax.
- **`widgets/Video_Popup.php`**: Removed `extract($settings)`. Standardized array syntax. Confirmed templates use `$settings`.
- **`widgets/Counter.php`**: Removed `extract($settings)`. Standardized array syntax.
- **`widgets/templates/counter/counter-2.php`**: Updated commented-out JS to use `$settings['counter_value']`.

### 🎯 Why
- **`extract($settings)`** is a bad practice that pollutes the symbol table, makes code hard to read (where did `$var` come from?), and confuses static analysis tools.
- **Logic Error**: `!empty($var == 'val')` is a convoluted way to check equality and relies on `empty()` behavior on booleans. Replaced with strict `===` comparisons.
- **Bug Fix**: `spel_readable_number` was multiplying all units by 1024 (treating 1GB as 1KB), which is incorrect.
- **Consistency**: Enforcing `[]` array syntax and Yoda conditions.

### 📊 Impact
- **Code Quality**: Improved readability, maintainability, and standards compliance.
- **Behavior**: `spel_readable_number` now returns correct values. No other functional changes intended (refactoring).

### 🧪 How Tested
- [x] PHP Syntax Check (`php -l`) on all modified files.
- [x] Unit Test (Script): Created `test_readable_number.php` to verify `spel_readable_number` returns correct byte values for 1K, 1M, 1G, 1T, 1P.
- [x] Manual Verification: Verified that widget templates for `Icon_Box`, `Video_Popup`, and `Counter` utilize `$settings` directly or have variables explicitly defined in `render()`.

### 🧩 Compatibility Notes
- PHP: 7.4+ (required by plugin)
- WordPress: 5.0+

---
*PR created automatically by Jules for task [1353359730118553985](https://jules.google.com/task/1353359730118553985) started by @mdjwel*