### PR TITLE
⚡ Bolt: Defer theme check and file loading to plugins_loaded

### DIFF
--- a/spider-elements.php
+++ b/spider-elements.php
@@ -252,12 +252,6 @@ if ( ! class_exists( 'SPEL' ) ) {
 			//Action Filter
 			require_once __DIR__ . '/includes/filters.php';
 
-			$theme = wp_get_theme();
-			if ( spel_is_premium() || in_array( $theme->get( 'Name' ), [ 'jobi', 'Jobi', 'jobi-child', 'Jobi Child' ] ) ) {
-				require_once __DIR__ . '/includes/Admin/extension/Heading_Highlighted.php';
-				require_once __DIR__ . '/includes/Admin/extension/Features_Badge.php';
-			}
-
 			// Admin UI
 			if ( is_admin() ) {
 				require_once __DIR__ . '/includes/Admin/Module_Settings.php';
@@ -295,11 +289,13 @@ if ( ! class_exists( 'SPEL' ) ) {
 				// Get the feature badge status
 				$heading_highlighted = $features_opt['spel_heading_highlighted'] ?? '';
 				if ( $heading_highlighted ) {
+					require_once __DIR__ . '/includes/Admin/extension/Heading_Highlighted.php';
 					new SPEL\includes\Admin\extension\Heading_Highlighted();
 				}
 
 				$badge = $features_opt['spel_badge'] ?? '';
 				if ( $badge ) {
+					require_once __DIR__ . '/includes/Admin/extension/Features_Badge.php';
 					new SPEL\includes\Admin\extension\Features_Badge();
 				}
 


### PR DESCRIPTION
Optimized the plugin initialization process by removing a redundant `wp_get_theme()` call and deferring the loading of extension files (`Heading_Highlighted.php` and `Features_Badge.php`) until the `plugins_loaded` hook. This reduces the bootstrap overhead on every page load and ensures files are only loaded when the features are actually enabled and required. This change also consolidates the logic for these extensions into `init_plugin`, preventing potential bugs where files might not be loaded if conditions were inconsistent.

---
*PR created automatically by Jules for task [1476298178699505906](https://jules.google.com/task/1476298178699505906) started by @mdjwel*