### PR TITLE
🛡️ Sentinel: [HIGH] Fix unsafe attribute parsing in spel_button_link

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -18,3 +18,15 @@ When parsing custom attributes from user input:
    - Or Whitelist: Only allow `data-*`, `aria-*`, `title`, `class`, `id`.
 2. **Handle Edge Cases:** Ensure `explode` has enough parts before accessing indexes to avoid PHP notices.
 3. **Defense in Depth:** Even if the input field is restricted to admins, protecting the output function guards against privilege escalation or DB compromises.
+
+## 2024-10-24 - Missing 'style' in Attribute Blacklist
+**Vulnerability:**
+While blocking `on*` events and `href` prevents direct XSS and link hijacking, omitting `style` from the blacklist allows for UI Redressing (Clickjacking) and Defacement.
+An attacker could inject `style="position:fixed;top:0;left:0;width:100%;height:100%;z-index:9999;opacity:0;"` to create an invisible overlay that intercepts clicks.
+
+**Learning:**
+Attribute blacklists must be comprehensive. `style` is often overlooked because it's "just CSS", but inline styles are powerful enough to break site usability or facilitate phishing attacks via overlays.
+Consistency across helper functions (e.g., `spel_el_image` blocked `style` but `spel_button_link` did not) is key to a secure codebase.
+
+**Prevention:**
+Always include `style` in attribute blacklists unless inline styling is a desired feature for the end user (which is rare for "Custom Attributes" fields intended for metadata).

--- a/includes/functions.php
+++ b/includes/functions.php
@@ -96,7 +96,7 @@ if ( ! function_exists( 'spel_button_link' ) ) {
 						$attr_name = preg_replace( '/[^a-zA-Z0-9_\-:]/', '', $attr_name );
 
 						// Security: Prevent XSS by blocking event handlers (on*) and critical attributes
-						if ( preg_match( '/^(on|href|src|formaction)/i', $attr_name ) ) {
+						if ( preg_match( '/^(on|style|formaction|src|href|target|rel)/i', $attr_name ) ) {
 							continue;
 						}
 


### PR DESCRIPTION
**Title:** 🛡️ Sentinel: [HIGH] Fix unsafe attribute parsing in `spel_button_link`

**Severity:** High (Potential for UI Redressing/Clickjacking and malicious attribute injection)

**Vulnerability Summary:**
The `spel_button_link` function allowed the injection of arbitrary `style`, `target`, and `rel` attributes via the "Custom Attributes" field. While `href` and `on*` events were blocked, omitting `style` allowed attackers to inject inline CSS (e.g., creating invisible overlays for clickjacking). Allowing `target` and `rel` permitted overriding the intended link behavior (e.g., enabling reverse tabnabbing).

**Impact:**
- **UI Redressing (Clickjacking):** Attackers could overlay the button with transparent elements or move it off-screen/over other content using inline styles.
- **Reverse Tabnabbing:** Attackers could force `target="_blank"` without `rel="noopener"`, potentially exposing the parent window object.
- **Defacement:** Arbitrary styling could break the site layout.

**Fix:**
- Updated the regex blacklist in `includes/functions.php` to strictly block `style`, `target`, and `rel` in custom attributes.
- The new regex is `/^(on|style|formaction|src|href|target|rel)/i`.

**Verification:**
- Validated using `reproduce_issue.php` which confirmed that `style="background:red"`, `target="_self"`, and `rel="opener"` are no longer outputted, while safe attributes like `data-test` are preserved.

---
*PR created automatically by Jules for task [5284575291446961990](https://jules.google.com/task/5284575291446961990) started by @mdjwel*