### PR TITLE
Refactor widget render methods to improve code quality

### DIFF
--- a/.warden/journal.md
+++ b/.warden/journal.md
@@ -9,3 +9,11 @@
 ## 2025-01-23 - Filters File Responsibility
 **Learning:** `includes/filters.php` is misnamed; it contains admin controller logic (form handling on `admin_init`).
 **Action:** Be aware that "filter" changes might actually involve admin form processing logic.
+
+## 2025-01-23 - Widget Template Variable Usage
+**Learning:** Widget templates in this codebase have inconsistent variable dependencies. Some (`Tabs`, `Team_Carousel`) rely on variables extracted from `$settings`, while others (`Video_Popup`, `Video_Playlist`) use `$settings` directly.
+**Action:** When refactoring `render()` methods, inspecting the corresponding template is mandatory to determine if variables need to be explicitly defined after removing `extract()`.
+
+## 2025-01-23 - Video Playlist Settings Retrieval
+**Learning:** The `Video_Playlist` widget uses `get_settings()` (raw settings) instead of `get_settings_for_display()` in its `render()` method, unlike other widgets.
+**Action:** Preserve this behavior when refactoring to avoid breaking dynamic functionality or repeater handling in that specific widget.

--- a/widgets/Accordion.php
+++ b/widgets/Accordion.php
@@ -650,22 +650,19 @@ class Accordion extends Widget_Base {
 	 * Package: @spider-elements
 	 * Author: spider-themes
 	 */
-	protected function render(): void
-    {
+	protected function render(): void {
+		$settings = $this->get_settings_for_display();
 
-        $settings = $this->get_settings_for_display();
-		extract( $settings );
+		$title_tag        = Utils::validate_html_tag( $settings['title_tag'] ?? 'h6' );
+		$accordions       = ! empty( $settings['accordions'] ) ? $settings['accordions'] : [];
+		$icon_align       = ! empty( $settings['icon_align'] ) ? $settings['icon_align'] : 'right';
+		$icon_align_class = 'left' === $icon_align ? ' icon-align-left' : '';
 
-		$title_tag 		  = Utils::validate_html_tag( $settings['title_tag'] ?? 'h6' );
-		$accordions       = ! empty ( $settings['accordions'] ) ? $settings['accordions'] : '';
-		$icon_align       = ! empty ( $settings['icon_align'] ) ? $settings['icon_align'] : 'right';
-		$icon_align_class = ! empty ( $icon_align == 'left' ) ? ' icon-align-left' : '';
-
-		$is_toggle           = ! empty ( $settings['is_toggle'] ) ? $settings['is_toggle'] : '';
-		$toggle_id           = ! empty( $is_toggle == 'yes' ) ? 'id=accordionExample-' . $this->get_id() : '';
-		$toggle_bs_parent_id = ! empty( $is_toggle == 'yes' ) ? 'data-bs-parent=#accordionExample-' . $this->get_id() : '';
+		$is_toggle           = ! empty( $settings['is_toggle'] ) ? $settings['is_toggle'] : '';
+		$toggle_id           = 'yes' === $is_toggle ? 'id=accordionExample-' . $this->get_id() : '';
+		$toggle_bs_parent_id = 'yes' === $is_toggle ? 'data-bs-parent=#accordionExample-' . $this->get_id() : '';
 
 		//======================== Template Parts ========================//
-		include "templates/accordion/accordion.php";
+		include __DIR__ . '/templates/accordion/accordion.php';
 	}
 }

--- a/widgets/Icon_Box.php
+++ b/widgets/Icon_Box.php
@@ -978,13 +978,13 @@ class Icon_Box extends Widget_Base {
 
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
+
 		$box_title_tag = Utils::validate_html_tag( $settings['box_title_tag'] ?? 'h6' );
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
-		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
+		$allowed_styles = [ '1', '2' ];
+		$style          = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/Icon-box/icon-box{$style}.php";
 	}
 }

--- a/widgets/Tabs.php
+++ b/widgets/Tabs.php
@@ -814,26 +814,27 @@ class Tabs extends Widget_Base {
 	 * Package: @spider-elements
 	 * Author: spider-themes
 	 */
-	protected function render(): void
-    {
-
+	protected function render(): void {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 
 		$tabs   = $this->get_settings_for_display( 'tabs' );
 		$id_int = substr( $this->get_id_int(), 0, 3 );
 
-		$navigation_arrow_class = ! empty( $is_navigation_arrow == 'yes' ) ? ' process_tab_shortcode' : '';
-		$sticky_tab_class       = ! empty( $is_sticky_tab == 'yes' ) ? ' sticky_tab' : '';
-        $tab_auto_class         = ! empty( $is_auto_play == 'yes' ) ? ' tab_auto_play' : '';
-        $data_auto_play         = ! empty( $is_auto_play == 'yes' ) ? ' data-autoplay=yes' : '';
+		$is_navigation_arrow = $settings['is_navigation_arrow'] ?? '';
+		$is_sticky_tab       = $settings['is_sticky_tab'] ?? '';
+		$is_auto_play        = $settings['is_auto_play'] ?? '';
+		$is_auto_numb        = $settings['is_auto_numb'] ?? '';
+
+		$navigation_arrow_class = 'yes' === $is_navigation_arrow ? ' process_tab_shortcode' : '';
+		$sticky_tab_class       = 'yes' === $is_sticky_tab ? ' sticky_tab' : '';
+		$tab_auto_class         = 'yes' === $is_auto_play ? ' tab_auto_play' : '';
+		$data_auto_play         = 'yes' === $is_auto_play ? ' data-autoplay=yes' : '';
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
-		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
+		$allowed_styles = [ '1', '2' ];
+		$style          = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/tabs/tab-{$style}.php";
-
 	}
 
 

--- a/widgets/Team_Carousel.php
+++ b/widgets/Team_Carousel.php
@@ -348,12 +348,14 @@ class Team_Carousel extends Widget_Base {
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
-		$team_id = $this->get_id();
+
+		$team_slider_item = $settings['team_slider_item'] ?? [];
+		$team_id          = $this->get_id();
+
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
-		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
+		$allowed_styles = [ '1', '2' ];
+		$style          = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/team/team-{$style}.php";
 	}
 

--- a/widgets/Video_Playlist.php
+++ b/widgets/Video_Playlist.php
@@ -847,17 +847,13 @@ class Video_Playlist extends Widget_Base {
 	 * Package: @spider-elements
 	 * Author: spider-themes
 	 */
-	protected function render(): void
-    {
-
-        $settings = $this->get_settings();
-		extract( $settings ); //extract all settings array to variables converted to name of a key
+	protected function render(): void {
+		$settings = $this->get_settings();
 
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
-		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
+		$allowed_styles = [ '1', '2' ];
+		$style          = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		// Render the widget output on the frontend.
 		include __DIR__ . "/templates/video-playlist/video-playlist-{$style}.php";
-
 	}
 }

--- a/widgets/Video_Popup.php
+++ b/widgets/Video_Popup.php
@@ -425,12 +425,11 @@ class Video_Popup extends Widget_Base {
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of a key
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
-		$allowed_styles = array( '1', '2' );
-		$style = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
+		$allowed_styles = [ '1', '2' ];
+		$style          = isset( $settings['style'] ) && in_array( $settings['style'], $allowed_styles, true ) ? $settings['style'] : '1';
 		include __DIR__ . "/templates/video-popup/video-popup-{$style}.php";
 	}
 }


### PR DESCRIPTION
##  Warden: Modernize Widget Render Methods

### 💡 What Changed
- Refactored `render()` methods in 6 widgets: `Accordion`, `Icon_Box`, `Tabs`, `Team_Carousel`, `Video_Playlist`, `Video_Popup`.
- Removed `extract( $settings )` call to prevent variable pollution and ambiguity.
- Explicitly defined variables required by included templates (e.g., `$team_slider_item`, `$tabs`).
- Fixed logic flaws in conditional checks (e.g., replaced `! empty( $var == 'yes' )` with `'yes' === $var`).
- Standardized template inclusion using `__DIR__`.
- Converted `array()` to `[]` in modified files.

### 🎯 Why
- **WPCS Violation / Best Practice:** `extract()` is discouraged as it makes code harder to debug and can overwrite local variables. Explicit definition makes dependencies clear.
- **Logic Fix:** `! empty( $var == 'yes' )` is a logical anti-pattern (checking if a boolean result is empty).
- **Consistency:** Standardizing path inclusion and array syntax improves maintainability.

### 📊 Impact
- **Code quality:** Improved readability, maintainability, and security (reduced variable scope pollution).
- **Behavior:** No functional changes. The templates receive the same variables they rely on.

### 🧪 How Tested
- [x] Syntax check: Ran `php -l` on all modified files and templates.
- [x] Template Analysis: Manually verified that all variables used in corresponding templates are either explicitly defined in `render()` or accessed via `$settings`.
- [x] Logic Verification: Confirmed that logic refactoring (Yoda conditions) preserves original intent.

### 🧩 Compatibility Notes
- PHP: 7.4+ (Compatible with existing requirement)
- WordPress: 5.0+

### 📋 Checklist
- [x] No breaking changes to public hooks/filters
- [x] No functional/behavior changes (style/quality only)
- [x] Changes scoped to stated theme only


---
*PR created automatically by Jules for task [1755951234860108364](https://jules.google.com/task/1755951234860108364) started by @mdjwel*