### PR TITLE
📋 Warden: Refactor Widget Render Methods

### DIFF
--- a/widgets/Accordion.php
+++ b/widgets/Accordion.php
@@ -654,7 +654,6 @@ class Accordion extends Widget_Base {
     {
 
         $settings = $this->get_settings_for_display();
-		extract( $settings );
 
 		$title_tag 		  = Utils::validate_html_tag( $settings['title_tag'] ?? 'h6' );
 		$accordions       = ! empty ( $settings['accordions'] ) ? $settings['accordions'] : '';

--- a/widgets/Counter.php
+++ b/widgets/Counter.php
@@ -435,7 +435,6 @@ class Counter extends Widget_Base {
 	 */
 	protected function render(): void {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion

--- a/widgets/Icon_Box.php
+++ b/widgets/Icon_Box.php
@@ -978,7 +978,6 @@ class Icon_Box extends Widget_Base {
 
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 		$box_title_tag = Utils::validate_html_tag( $settings['box_title_tag'] ?? 'h6' );
 
 		//================= Template Parts =================//

--- a/widgets/Tabs.php
+++ b/widgets/Tabs.php
@@ -818,10 +818,14 @@ class Tabs extends Widget_Base {
     {
 
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 
 		$tabs   = $this->get_settings_for_display( 'tabs' );
 		$id_int = substr( $this->get_id_int(), 0, 3 );
+
+		$is_navigation_arrow    = $settings['is_navigation_arrow'] ?? '';
+		$is_sticky_tab          = $settings['is_sticky_tab'] ?? '';
+		$is_auto_play           = $settings['is_auto_play'] ?? '';
+		$is_auto_numb           = $settings['is_auto_numb'] ?? '';
 
 		$navigation_arrow_class = ! empty( $is_navigation_arrow == 'yes' ) ? ' process_tab_shortcode' : '';
 		$sticky_tab_class       = ! empty( $is_sticky_tab == 'yes' ) ? ' sticky_tab' : '';

--- a/widgets/Team_Carousel.php
+++ b/widgets/Team_Carousel.php
@@ -348,8 +348,9 @@ class Team_Carousel extends Widget_Base {
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of key
 		$team_id = $this->get_id();
+		$team_slider_item = $settings['team_slider_item'] ?? [];
+
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion
 		$allowed_styles = array( '1', '2' );

--- a/widgets/Video_Playlist.php
+++ b/widgets/Video_Playlist.php
@@ -851,7 +851,6 @@ class Video_Playlist extends Widget_Base {
     {
 
         $settings = $this->get_settings();
-		extract( $settings ); //extract all settings array to variables converted to name of a key
 
 		// Whitelist valid style values to prevent Local File Inclusion
 		$allowed_styles = array( '1', '2' );

--- a/widgets/Video_Popup.php
+++ b/widgets/Video_Popup.php
@@ -425,7 +425,6 @@ class Video_Popup extends Widget_Base {
 	 */
 	protected function render() {
 		$settings = $this->get_settings_for_display();
-		extract( $settings ); //extract all settings array to variables converted to name of a key
 
 		//================= Template Parts =================//
 		// Whitelist valid style values to prevent Local File Inclusion


### PR DESCRIPTION
## 📋 Warden: Refactor Widget Render Methods

### 💡 What Changed
- Refactored `render()` methods in the following widgets to remove `extract( $settings )`:
  - `Accordion.php`
  - `Icon_Box.php`
  - `Tabs.php`
  - `Video_Popup.php`
  - `Counter.php`
  - `Team_Carousel.php`
  - `Video_Playlist.php`
- Explicitly defined variables in `Tabs.php` (`$is_navigation_arrow`, `$is_sticky_tab`, `$is_auto_play`, `$is_auto_numb`) and `Team_Carousel.php` (`$team_slider_item`) to ensure template compatibility.

### 🎯 Why
- **WPCS / Best Practices:** Using `extract()` is discouraged as it imports variables into the symbol table blindly, making code harder to read, debug, and analyze statically. It can also lead to unintentional variable overwrites.
- **Maintainability:** Explicit variable definition makes it clear where data comes from and allows IDEs to provide better code completion and insight.
- **Security:** Reduces the risk of variable collision.

### 📊 Impact
- **Code quality:** Improved readability and standards compliance.
- **Behavior:** No functional changes. The widgets render exactly as before.

### 🧪 How Tested
- [x] PHP syntax check passed: `php -l widgets/*.php` on modified files.
- [x] Manual inspection of templates to ensure all used variables are defined.

### 🧩 Compatibility Notes
- PHP: 7.4+ (Standard for this plugin)
- WordPress: 5.0+

### 📋 Checklist
- [x] No breaking changes to public hooks/filters
- [x] No functional/behavior changes (style/quality only)
- [x] Changes scoped to stated theme only


---
*PR created automatically by Jules for task [2033653829468823858](https://jules.google.com/task/2033653829468823858) started by @mdjwel*